### PR TITLE
Disable Python output buffering for endpoint logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ dmypy.json
 
 src/autogluon/cloud/version.py
 VERSION.minor
+.idea

--- a/src/autogluon/cloud/utils/ag_sagemaker.py
+++ b/src/autogluon/cloud/utils/ag_sagemaker.py
@@ -138,7 +138,14 @@ class AutoGluonSagemakerInferenceModel(Model):
                 instance_type=instance_type,
             )
         # setting PYTHONUNBUFFERED to disable output buffering for endpoints logging
-        super().__init__(model_data=model_data, role=role, entry_point=entry_point, image_uri=image_uri, env={"PYTHONUNBUFFERED": "1"}, **kwargs)
+        super().__init__(
+            model_data=model_data,
+            role=role,
+            entry_point=entry_point,
+            image_uri=image_uri,
+            env={"PYTHONUNBUFFERED": "1"},
+            **kwargs,
+        )
 
     def transformer(
         self,

--- a/src/autogluon/cloud/utils/ag_sagemaker.py
+++ b/src/autogluon/cloud/utils/ag_sagemaker.py
@@ -137,7 +137,8 @@ class AutoGluonSagemakerInferenceModel(Model):
                 image_scope="inference",
                 instance_type=instance_type,
             )
-        super().__init__(model_data=model_data, role=role, entry_point=entry_point, image_uri=image_uri, **kwargs)
+        # setting PYTHONUNBUFFERED to disable output buffering for endpoints logging
+        super().__init__(model_data=model_data, role=role, entry_point=entry_point, image_uri=image_uri, env={"PYTHONUNBUFFERED": "1"}, **kwargs)
 
     def transformer(
         self,


### PR DESCRIPTION
Issue #, if available:


Description of changes:
Disable Python output buffering for endpoint logging. See logging emitted after this change
```
2022-12-21T00:57:37,730 [WARN ] W-model-9-stderr com.amazonaws.ml.mms.wlm.WorkerLifeCycle - /usr/local/lib/python3.8/dist-packages/autogluon/multimodal/utils/environment.py:54: UserWarning: Using the detected GPU number 0, smaller than the GPU number 1 in the config.
```
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
