### PR TITLE
[CI]Add test 0.6.1

### DIFF
--- a/.github/actions/test-cloud/action.yml
+++ b/.github/actions/test-cloud/action.yml
@@ -2,6 +2,9 @@ name: "Test Cloud Module"
 inputs:
   submodule-to-test:
     required: true
+  ag_version:
+    required: false
+    default: source
 
 runs:
   using: "composite"
@@ -15,4 +18,4 @@ runs:
     - name: Test Cloud Submodule
       shell: bash
       run: |
-        chmod +x ./.github/workflow_scripts/test_cloud.sh && ./.github/workflow_scripts/test_cloud.sh '${{ inputs.submodule-to-test }}'
+        chmod +x ./.github/workflow_scripts/test_cloud.sh && ./.github/workflow_scripts/test_cloud.sh '${{ inputs.submodule-to-test }}' '${{ inputs.ag_version }}'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -55,6 +55,9 @@ jobs:
         run: |
           chmod +x ./.github/workflow_scripts/cloud_lint_check.sh && ./.github/workflow_scripts/cloud_lint_check.sh
   test_general_cloud:
+    strategy:
+      matrix:
+        AG_VERSION: ["source", "0.6.1"]
     needs: cloud_lint_check
     runs-on: ubuntu-latest
     steps:
@@ -73,7 +76,11 @@ jobs:
         uses: ./.github/actions/test-cloud
         with:
           submodule-to-test: general
+          ag_version: '${{ matrix.AG_VERSION }}'
   test_tabular_cloud:
+    strategy:
+      matrix:
+        AG_VERSION: ["source", "0.6.1"]
     needs: cloud_lint_check
     runs-on: ubuntu-latest
     steps:
@@ -92,7 +99,11 @@ jobs:
         uses: ./.github/actions/test-cloud
         with:
           submodule-to-test: tabular
+          ag_version: '${{ matrix.AG_VERSION }}'
   test_text_cloud:
+    strategy:
+      matrix:
+        AG_VERSION: ["source", "0.6.1"]
     needs: cloud_lint_check
     runs-on: ubuntu-latest
     steps:
@@ -111,7 +122,11 @@ jobs:
         uses: ./.github/actions/test-cloud
         with:
           submodule-to-test: text
+          ag_version: '${{ matrix.AG_VERSION }}'
   test_image_cloud:
+    strategy:
+      matrix:
+        AG_VERSION: ["source", "0.6.1"]
     needs: cloud_lint_check
     runs-on: ubuntu-latest
     steps:
@@ -130,7 +145,11 @@ jobs:
         uses: ./.github/actions/test-cloud
         with:
           submodule-to-test: image
+          ag_version: '${{ matrix.AG_VERSION }}'
   test_multimodal_cloud:
+    strategy:
+      matrix:
+        AG_VERSION: ["source", "0.6.1"]
     needs: cloud_lint_check
     runs-on: ubuntu-latest
     steps:
@@ -149,3 +168,4 @@ jobs:
         uses: ./.github/actions/test-cloud
         with:
           submodule-to-test: multimodal
+          ag_version: '${{ matrix.AG_VERSION }}'

--- a/setup.py
+++ b/setup.py
@@ -111,8 +111,7 @@ install_requires = [
     "numpy>=1.21.4,<2.0",
     "packaging>=21.0,<22.0",
     "pandas>=1.2.5,<2.0",
-    # TODO: update to the latest after 0.6 container is out
-    "sagemaker>=2.94",
+    "sagemaker>=2.126.0",
     "pyarrow>=9.0,<10.0",
     "PyYAML>=6.0,<7.0",
     "Pillow>=9.3.0,<10.0",

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -424,6 +424,7 @@ class CloudPredictor(ABC):
             Training container version of autogluon.
             If `latest`, will use the latest available container version.
             If provided a specific version, will use this version.
+            If `custom_image_uri` is set, this argument will be ignored.
         job_name: str, default = None
             Name of the launched training job.
             If None, CloudPredictor will create one with prefix ag-cloudpredictor
@@ -639,6 +640,7 @@ class CloudPredictor(ABC):
             Inference container version of autogluon.
             If `latest`, will use the latest available container version.
             If provided a specific version, will use this version.
+            If `custom_image_uri` is set, this argument will be ignored.
         instance_type: str, default = 'ml.m5.2xlarge'
             Instance to be deployed for the endpoint
         initial_instance_count: int, default = 1,
@@ -856,6 +858,7 @@ class CloudPredictor(ABC):
             Inference container version of autogluon.
             If `latest`, will use the latest available container version.
             If provided a specific version, will use this version.
+            If `custom_image_uri` is set, this argument will be ignored.
         job_name: str, default = None
             Name of the launched training job.
             If None, CloudPredictor will create one with prefix ag-cloudpredictor.

--- a/tests/unittests/general/test_full_functionality.py
+++ b/tests/unittests/general/test_full_functionality.py
@@ -3,7 +3,7 @@ import tempfile
 from autogluon.cloud import TabularCloudPredictor
 
 
-def test_full_functionality(test_helper, framework_version="source"):
+def test_full_functionality(test_helper, framework_version):
     """
     Use tabular as an example to test full functionality.
     Those functionalities shouldn't differ between modality

--- a/tests/unittests/image/test_image.py
+++ b/tests/unittests/image/test_image.py
@@ -3,7 +3,7 @@ import tempfile
 from autogluon.cloud import ImageCloudPredictor, MultiModalCloudPredictor
 
 
-def test_image(test_helper, framework_version="source"):
+def test_image(test_helper, framework_version):
     train_data = "image_train_relative.csv"
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"

--- a/tests/unittests/multimodal/test_multimodal.py
+++ b/tests/unittests/multimodal/test_multimodal.py
@@ -3,7 +3,7 @@ import tempfile
 from autogluon.cloud import MultiModalCloudPredictor
 
 
-def test_multimodal_tabular_text_image(test_helper, framework_version="source"):
+def test_multimodal_tabular_text_image(test_helper, framework_version):
     train_data = "tabular_text_image_train.csv"
     test_data = "tabular_text_image_test.csv"
     images = "tabular_text_image_images.zip"

--- a/tests/unittests/tabular/test_tabular.py
+++ b/tests/unittests/tabular/test_tabular.py
@@ -2,6 +2,7 @@ import tempfile
 
 from autogluon.cloud import TabularCloudPredictor
 
+
 def test_tabular_tabular_text_image(test_helper, framework_version):
     train_data = "tabular_text_image_train.csv"
     test_data = "tabular_text_image_test.csv"

--- a/tests/unittests/tabular/test_tabular.py
+++ b/tests/unittests/tabular/test_tabular.py
@@ -2,8 +2,7 @@ import tempfile
 
 from autogluon.cloud import TabularCloudPredictor
 
-
-def test_tabular_tabular_text_image(test_helper, framework_version="source"):
+def test_tabular_tabular_text_image(test_helper, framework_version):
     train_data = "tabular_text_image_train.csv"
     test_data = "tabular_text_image_test.csv"
     images = "tabular_text_image_images.zip"

--- a/tests/unittests/text/test_text.py
+++ b/tests/unittests/text/test_text.py
@@ -1,37 +1,6 @@
 import tempfile
 
-from autogluon.cloud import MultiModalCloudPredictor, TextCloudPredictor
-
-
-def test_text(test_helper, framework_version="source"):
-    train_data = "text_train.csv"
-    tune_data = "text_tune.csv"
-    test_data = "text_test.csv"
-    timestamp = test_helper.get_utc_timestamp_now()
-    with tempfile.TemporaryDirectory() as _:
-        test_helper.prepare_data(train_data, tune_data, test_data)
-        time_limit = 60
-
-        predictor_init_args = dict(label="label", eval_metric="acc")
-        predictor_fit_args = dict(train_data=train_data, tuning_data=tune_data, time_limit=time_limit)
-        cloud_predictor = TextCloudPredictor(
-            cloud_output_path=f"s3://autogluon-cloud-ci/test-text/{timestamp}",
-            local_output_path="test_text_cloud_predictor",
-        )
-        training_custom_image_uri, inference_custom_image_uri = test_helper.get_custom_image_uri(framework_version)
-        test_helper.test_basic_functionality(
-            cloud_predictor,
-            predictor_init_args,
-            predictor_fit_args,
-            test_data,
-            fit_kwargs=dict(
-                instance_type="ml.g4dn.2xlarge",
-                framework_version=framework_version,
-                custom_image_uri=training_custom_image_uri,
-            ),
-            deploy_kwargs=dict(framework_version=framework_version, custom_image_uri=inference_custom_image_uri),
-            predict_kwargs=dict(framework_version=framework_version, custom_image_uri=inference_custom_image_uri),
-        )
+from autogluon.cloud import MultiModalCloudPredictor
 
 
 def test_multimodal_text_only(test_helper, framework_version="source"):

--- a/tests/unittests/text/test_text.py
+++ b/tests/unittests/text/test_text.py
@@ -3,7 +3,7 @@ import tempfile
 from autogluon.cloud import MultiModalCloudPredictor
 
 
-def test_multimodal_text_only(test_helper, framework_version="source"):
+def test_multimodal_text_only(test_helper, framework_version):
     train_data = "text_train.csv"
     tune_data = "text_tune.csv"
     test_data = "text_test.csv"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Add CI to test 0.6.1 framework.
* Remove test of TextCloudPredictor as it is basically the same as tabular in terms of cloud logic.
* Set lower bound for sagmaker sdk to support 0.6.1 container

**Cancel PR CI run to save resource intentionally**

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
