### PR TITLE
Download batch transform results in predict call

### DIFF
--- a/docs/tutorials/autogluon-cloud.md
+++ b/docs/tutorials/autogluon-cloud.md
@@ -144,15 +144,22 @@ A general guideline is to use batch inference if you need to get predictions les
 To perform batch inference:
 
 ```{.python}
-cloud_predictor.predict(
+result = cloud_predictor.predict(
     'test.csv',  # can be a DataFrame as well and the results will be stored in s3 bucket
     instance_type="ml.m5.2xlarge",  # Checkout supported instance and pricing here: https://aws.amazon.com/sagemaker/pricing/
-    wait=True  # Set this to False to make it unblocking call
+    wait=True,  # Set this to False to make it unblocking call
+    download=True  # Batch transform results are stored into S3. Set this to False if you don't want to download the results.
+    persist=True  # Set this to False is you don't want to keep the results file being downloaded
+    save_path=None  # Path to save the downloaded results. If not said, CloudPredictor will create one.
 )
-cloud_predictor.download_predict_results(
-    job_name=None  # download the most recent finished batch inference results to your local machine. Specify the job name to download a specific batch inference job's results.
-    save_path="PATH"  # If not specified, CloudPredictor will create one.
-)
+```
+
+Result would be a pandas DataFrame similar to this:
+
+```{.python}
+   pred   0_proba   1_proba
+0     1  0.317246  0.682754
+1     1  0.195782  0.804218
 ```
 
 ## Retrieve CloudPredictor Info

--- a/docs/tutorials/autogluon-cloud.md
+++ b/docs/tutorials/autogluon-cloud.md
@@ -62,7 +62,7 @@ cloud_predictor = TabularCloudPredictor(
     predictor_init_args,
     predictor_fit_args,
     instance_type="ml.m5.2xlarge"  # Checkout supported instance and pricing here: https://aws.amazon.com/sagemaker/pricing/
-    wait=True  # Set this to False to make it unblocking call
+    wait=True  # Set this to False to make it an unblocking call and immediately return
 )
 ```
 
@@ -86,7 +86,7 @@ If you want to deploy a predictor as a SageMaker endpoint, which can be used to 
 ```{.python}
 cloud_predictor.deploy(
     instance_type="ml.m5.2xlarge",  # Checkout supported instance and pricing here: https://aws.amazon.com/sagemaker/pricing/
-    wait=True  # Set this to False to make it unblocking call
+    wait=True  # Set this to False to make it an unblocking call and immediately return
 )
 ```
 
@@ -102,7 +102,7 @@ To perform real-time prediction:
 result = cloud_predictor.predict_real_time(
     'test.csv',  # can be a DataFrame as well
     instance_type="ml.m5.2xlarge",  # Checkout supported instance and pricing here: https://aws.amazon.com/sagemaker/pricing/
-    wait=True  # Set this to False to make it unblocking call
+    wait=True  # Set this to False to make it an unblocking call and immediately return
 )
 ```
 
@@ -147,10 +147,12 @@ To perform batch inference:
 result = cloud_predictor.predict(
     'test.csv',  # can be a DataFrame as well and the results will be stored in s3 bucket
     instance_type="ml.m5.2xlarge",  # Checkout supported instance and pricing here: https://aws.amazon.com/sagemaker/pricing/
-    wait=True,  # Set this to False to make it unblocking call
-    download=True  # Batch transform results are stored into S3. Set this to False if you don't want to download the results.
-    persist=True  # Set this to False is you don't want to keep the results file being downloaded
-    save_path=None  # Path to save the downloaded results. If not said, CloudPredictor will create one.
+    wait=True,  # Set this to False to make it an unblocking call and immediately return
+    # If True, returns a Pandas Series object of predictions.
+    # If False, returns nothing. You will have to download results separately via cloud_predictor.download_predict_results
+    download=True,
+    persist=True,  # If True and download=True, the results file will also be saved to local disk.
+    save_path=None  # Path to save the downloaded results. If None, CloudPredictor will create one with the batch inference job name.
 )
 ```
 

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -838,6 +838,8 @@ class CloudPredictor(ABC):
         instance_count=1,
         custom_image_uri=None,
         wait=True,
+        download=True,
+        save_path=None,
         model_kwargs=None,
         transformer_kwargs=None,
         **kwargs,
@@ -875,6 +877,13 @@ class CloudPredictor(ABC):
         wait: bool, default = True
             Whether to wait for batch transform to complete.
             To be noticed, the function won't return immediately because there are some preparations needed prior transform.
+        download: bool, default = True
+            Whether to download the batch transform results to the disk and load it after the batch transform finishes.
+            Will be ignored if `wait` is `False`.
+        save_path: str, default = None,
+            Path to save the downloaded result.
+            Will be ignored if `download` is `False`.
+            If None, CloudPredictor will create one.
         model_kwargs: dict, default = dict()
             Any extra arguments needed to initialize Sagemaker Model
             Please refer to https://sagemaker.readthedocs.io/en/stable/api/inference/model.html#model for all options

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -972,14 +972,20 @@ class CloudPredictor(ABC):
 
         if not wait:
             if download:
-                logger.warning(f"`download={download}` will be ignored because `wait={wait}`. Setting `download` to `False`.")
+                logger.warning(
+                    f"`download={download}` will be ignored because `wait={wait}`. Setting `download` to `False`."
+                )
                 download = False
         if not download:
             if persist:
-                logger.warning(f"`persist={persist}` will be ignored because `download={download}`. Setting `persist` to `False`.")
+                logger.warning(
+                    f"`persist={persist}` will be ignored because `download={download}`. Setting `persist` to `False`."
+                )
                 persist = False
             if save_path:
-                logger.warning(f"`save_path={save_path}` will be ignored because `download={download}`. Setting `save_path` to `None`.")
+                logger.warning(
+                    f"`save_path={save_path}` will be ignored because `download={download}`. Setting `save_path` to `None`."
+                )
                 save_path = None
 
         batch_transform_job = SageMakerBatchTransformationJob(session=self.sagemaker_session)

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -979,7 +979,7 @@ class CloudPredictor(ABC):
                 persist = False
             if save_path:
                 logger.warning("`save_path` will be ignored because `download` is set to `False`")
-                save_path = False
+                save_path = None
 
         batch_transform_job = SageMakerBatchTransformationJob(session=self.sagemaker_session)
         batch_transform_job.run(

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -45,12 +45,7 @@ from ..utils.sagemaker_utils import (
     retrieve_latest_framework_version,
     retrieve_py_versions,
 )
-from ..utils.utils import (
-    convert_image_path_to_encoded_bytes_in_dataframe,
-    is_image_file,
-    unzip_file,
-    zipfolder,
-)
+from ..utils.utils import convert_image_path_to_encoded_bytes_in_dataframe, is_image_file, unzip_file, zipfolder
 
 logger = logging.getLogger(__name__)
 
@@ -973,7 +968,7 @@ class CloudPredictor(ABC):
             split_type = kwargs.pop("split_type")
         if not content_type:
             content_type = "text/csv"
-            
+
         if not wait:
             if download:
                 logger.warning("`download` will be ignored because `wait` is set to `False`")
@@ -1010,7 +1005,7 @@ class CloudPredictor(ABC):
             **kwargs,
         )
         self._batch_transform_jobs[job_name] = batch_transform_job
-        
+
         results = None
         if download:
             results_path = self.download_predict_results(save_path=save_path)
@@ -1033,7 +1028,7 @@ class CloudPredictor(ABC):
         save_path: str
             Path to save the downloaded results.
             If None, CloudPredictor will create one.
-            
+
         Returns
         -------
         str,
@@ -1060,7 +1055,7 @@ class CloudPredictor(ABC):
         )
         results_save_path = os.path.join(results_save_path, file_name)
         logger.log(20, f"Batch results have been downloaded to {results_save_path}")
-        
+
         return results_save_path
 
     def get_batch_transform_job_status(self, job_name=None):

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -893,6 +893,7 @@ class CloudPredictor(ABC):
             Any extra arguments needed to pass to transform.
             Please refer to
             https://sagemaker.readthedocs.io/en/stable/api/inference/transformer.html#sagemaker.transformer.Transformer.transform for all options.
+
         Returns
         -------
         Optional Pandas.DataFrame
@@ -971,14 +972,14 @@ class CloudPredictor(ABC):
 
         if not wait:
             if download:
-                logger.warning("`download` will be ignored because `wait` is set to `False`")
+                logger.warning(f"`download={download}` will be ignored because `wait={wait}`. Setting `download` to `False`.")
                 download = False
         if not download:
             if persist:
-                logger.warning("`persist` will be ignored because `download` is set to `False`")
+                logger.warning(f"`persist={persist}` will be ignored because `download={download}`. Setting `persist` to `False`.")
                 persist = False
             if save_path:
-                logger.warning("`save_path` will be ignored because `download` is set to `False`")
+                logger.warning(f"`save_path={save_path}` will be ignored because `download={download}`. Setting `save_path` to `None`.")
                 save_path = None
 
         batch_transform_job = SageMakerBatchTransformationJob(session=self.sagemaker_session)

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -48,7 +48,6 @@ from ..utils.sagemaker_utils import (
 from ..utils.utils import (
     convert_image_path_to_encoded_bytes_in_dataframe,
     is_image_file,
-    append_file_with_job_name,
     unzip_file,
     zipfolder,
 )
@@ -839,6 +838,7 @@ class CloudPredictor(ABC):
         custom_image_uri=None,
         wait=True,
         download=True,
+        persist=True,
         save_path=None,
         model_kwargs=None,
         transformer_kwargs=None,
@@ -880,10 +880,14 @@ class CloudPredictor(ABC):
         download: bool, default = True
             Whether to download the batch transform results to the disk and load it after the batch transform finishes.
             Will be ignored if `wait` is `False`.
+        persist: bool, default = True
+            Whether to persist the downloaded batch transform results on the disk.
+            Will be ignored if `download` is `False`
         save_path: str, default = None,
             Path to save the downloaded result.
             Will be ignored if `download` is `False`.
             If None, CloudPredictor will create one.
+            If `persist` is `False`, file would first be downloaded to this path and then removed.
         model_kwargs: dict, default = dict()
             Any extra arguments needed to initialize Sagemaker Model
             Please refer to https://sagemaker.readthedocs.io/en/stable/api/inference/model.html#model for all options
@@ -894,6 +898,11 @@ class CloudPredictor(ABC):
             Any extra arguments needed to pass to transform.
             Please refer to
             https://sagemaker.readthedocs.io/en/stable/api/inference/transformer.html#sagemaker.transformer.Transformer.transform for all options.
+        Returns
+        -------
+        Optional Pandas.DataFrame
+        Predict results in DataFrame if `download` is True
+        None if `download` is False
         """
         if not predictor_path:
             predictor_path = self._fit_job.get_output_path()
@@ -970,6 +979,9 @@ class CloudPredictor(ABC):
                 logger.warning("`download` will be ignored because `wait` is set to `False`")
                 download = False
         if not download:
+            if persist:
+                logger.warning("`persist` will be ignored because `download` is set to `False`")
+                persist = False
             if save_path:
                 logger.warning("`save_path` will be ignored because `download` is set to `False`")
                 save_path = False
@@ -998,6 +1010,16 @@ class CloudPredictor(ABC):
             **kwargs,
         )
         self._batch_transform_jobs[job_name] = batch_transform_job
+        
+        results = None
+        if download:
+            results_path = self.download_predict_results(save_path=save_path)
+            # Batch inference will only return json format
+            results = pd.read_json(results_path)
+        if not persist:
+            os.remove(results_path)
+
+        return results
 
     def download_predict_results(self, job_name=None, save_path=None):
         """
@@ -1006,11 +1028,16 @@ class CloudPredictor(ABC):
         Parameters
         ----------
         job_name: str
-            The specific batch transform job result to download.
-            If None, will download the most recent job result.
+            The specific batch transform job results to download.
+            If None, will download the most recent job results.
         save_path: str
-            Path to save the downloaded result.
+            Path to save the downloaded results.
             If None, CloudPredictor will create one.
+            
+        Returns
+        -------
+        str,
+            Path to downloaded results.
         """
         if not job_name:
             job_name = self._batch_transform_jobs.last
@@ -1020,7 +1047,6 @@ class CloudPredictor(ABC):
         result_path = job.get_output_path()
         assert result_path is not None, "No predict results found."
         file_name = result_path.split("/")[-1]
-        file_name = append_file_with_job_name(file_name, job_name)
         if not save_path:
             save_path = self.local_output_path
         save_path = os.path.expanduser(save_path)
@@ -1028,11 +1054,14 @@ class CloudPredictor(ABC):
         results_save_path = os.path.join(save_path, "batch_transform", job_name)
         if not os.path.isdir(results_save_path):
             os.makedirs(results_save_path)
-        results_save_path = os.path.join(results_save_path, file_name)
         results_bucket, results_key_prefix = s3_path_to_bucket_prefix(result_path)
         self.sagemaker_session.download_data(
             path=results_save_path, bucket=results_bucket, key_prefix=results_key_prefix
         )
+        results_save_path = os.path.join(results_save_path, file_name)
+        logger.log(20, f"Batch results have been downloaded to {results_save_path}")
+        
+        return results_save_path
 
     def get_batch_transform_job_status(self, job_name=None):
         """

--- a/src/autogluon/cloud/predictor/image_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/image_cloud_predictor.py
@@ -84,7 +84,7 @@ class ImageCloudPredictor(CloudPredictor):
         kwargs = copy.deepcopy(kwargs)
         transformer_kwargs = kwargs.pop("transformer_kwargs", dict())
         transformer_kwargs["strategy"] = "SingleRecord"
-        super().predict(
+        return super().predict(
             test_data,
             split_type=split_type,
             content_type=content_type,

--- a/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/multimodal_cloud_predictor.py
@@ -118,7 +118,7 @@ class MultiModalCloudPredictor(CloudPredictor):
             kwargs = copy.deepcopy(kwargs)
             transformer_kwargs = kwargs.pop("transformer_kwargs", dict())
             transformer_kwargs["strategy"] = "SingleRecord"
-            super().predict(
+            return super().predict(
                 test_data,
                 test_data_image_column=None,
                 split_type=split_type,
@@ -127,7 +127,7 @@ class MultiModalCloudPredictor(CloudPredictor):
                 **kwargs,
             )
         else:
-            super().predict(
+            return super().predict(
                 test_data,
                 test_data_image_column=test_data_image_column,
                 **kwargs,

--- a/src/autogluon/cloud/utils/__init__.py
+++ b/src/autogluon/cloud/utils/__init__.py
@@ -10,7 +10,6 @@ from .utils import (
     is_compressed_file,
     is_image_file,
     read_image_bytes_and_encode,
-    rename_file_with_uuid,
     unzip_file,
     zipfolder,
 )

--- a/src/autogluon/cloud/utils/utils.py
+++ b/src/autogluon/cloud/utils/utils.py
@@ -4,7 +4,6 @@ import logging
 import os
 import shutil
 import tarfile
-import uuid
 import zipfile
 
 import PIL
@@ -65,16 +64,3 @@ def unzip_file(tarball_path, save_path):
     file = tarfile.open(tarball_path)
     file.extractall(save_path)
     file.close()
-
-
-def append_file_with_job_name(file_name, job_name):
-    tmp = file_name.rsplit(".", 1)
-    name = tmp[0]
-    if len(tmp) > 1:
-        extension = tmp[1]
-        joiner = "."
-    else:
-        extension = ""
-        joiner = ""
-    new_file_name = name + "_" + job_name + joiner + extension
-    return new_file_name

--- a/src/autogluon/cloud/utils/utils.py
+++ b/src/autogluon/cloud/utils/utils.py
@@ -67,7 +67,7 @@ def unzip_file(tarball_path, save_path):
     file.close()
 
 
-def rename_file_with_uuid(file_name):
+def append_file_with_job_name(file_name, job_name):
     tmp = file_name.rsplit(".", 1)
     name = tmp[0]
     if len(tmp) > 1:
@@ -76,5 +76,5 @@ def rename_file_with_uuid(file_name):
     else:
         extension = ""
         joiner = ""
-    new_file_name = name + "_" + str(uuid.uuid4()) + joiner + extension
+    new_file_name = name + "_" + job_name + joiner + extension
     return new_file_name


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Add flags to enable user get batch transform results directly in a `predict` call
* Removed the uuid renaming as the folder has already been generated based on job_name. No need to rename file. And with uuid you cannot log it as it triggers security concern.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
