### PR TITLE
[Cloud] support deployment with pretrained models

### DIFF
--- a/src/autogluon/cloud/job/sagemaker_job.py
+++ b/src/autogluon/cloud/job/sagemaker_job.py
@@ -149,7 +149,7 @@ class SageMakerFitJob(SageMakerJob):
         if not self._local_mode:
             return self.session.describe_training_job(self.job_name)["ModelArtifacts"]["S3ModelArtifacts"]
         assert self._output_path is not None
-        return self._output_path + "/" + self._output_filename
+        return self._output_path + self._output_filename
 
     def run(
         self,

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -1401,7 +1401,7 @@ class CloudPredictor(ABC):
             predictor._fit_job = SageMakerFitJob()
             predictor._fit_job._local_mode = True
             predictor._fit_job._output_path = path
-        except Exception as err:
+        except Exception:
             raise
         predictor.sagemaker_session = setup_sagemaker_session()
         predictor._region = predictor.sagemaker_session.boto_region_name


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This PR brings the support to deploy models that are not trained with CloudPredictor.

For instance, users could train a model locally, and upload it to S3

```bash
aws s3 cp model.tar.gz s3://my-bucket-us-west-2/models/my_pretrained_model/
```

Then jump start with cloud module for deployment and real-time prediction.

```python
from autogluon.cloud import MultiModalCloudPredictor

cloud_predictor = MultiModalCloudPredictor.load(path="s3://my-bucket-us-west-2/models/my_pretrained_model")
cloud_predictor.role_arn = "arn:aws:iam::111111111111:role/service-role/AmazonSageMaker-ExecutionRole-20200000T111111"
cloud_predictor.deploy(
    instance_type="ml.g4dn.2xlarge",
    wait=True
)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
