### PR TITLE
Fix external rst links on landing page

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,9 +14,9 @@ AutoGluon-Cloud: Train and Deploy AutoGluon on the Cloud
 
 |ReleaseVersion| |StableVersion| |PythonVersion| |License|
 
-AutoGluon-Cloud aims to provide user tools to train, fine-tune and deploy [AutoGluon](https://auto.gluon.ai/stable/index.html) backed models on the cloud. With just a few lines of codes, users could train a model and perform inference on the cloud without worrying about MLOps details such as resource management.
+AutoGluon-Cloud aims to provide user tools to train, fine-tune and deploy `AutoGluon <https://auto.gluon.ai/stable/index.html>`_ backed models on the cloud. With just a few lines of code, users can train a model and perform inference on the cloud without worrying about MLOps details such as resource management.
 
-Currently, AutoGluon-Cloud supports [AWS SageMaker](https://aws.amazon.com/sagemaker/) as the cloud backend.
+Currently, AutoGluon-Cloud supports `AWS SageMaker <https://aws.amazon.com/sagemaker/>`_ as the cloud backend.
 
 .. note::
 


### PR DESCRIPTION
Description of changes:

This change updates the external links on the landing page from Markdown syntax to [rst sytax](https://sublime-and-sphinx-guide.readthedocs.io/en/latest/references.html#links-to-external-web-pages). The current links are not being rendered correctly on the website.

While I was here, I updated a few words as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
