### PR TITLE
Fix logger

### DIFF
--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -22,7 +22,7 @@ from ..backend.constant import SAGEMAKER
 from ..endpoint.endpoint import Endpoint
 from ..utils.utils import unzip_file
 
-logger = logging.getLogger("autogluon.cloud")
+logger = logging.getLogger("__name__")
 
 
 class CloudPredictor(ABC):
@@ -56,7 +56,8 @@ class CloudPredictor(ABC):
             where `L` ranges from 0 to 50 (Note: higher values of `L` correspond to fewer print statements, opposite of verbosity levels).
         """
         self.verbosity = verbosity
-        set_logger_verbosity(self.verbosity, logger=logger)
+        cloud_logger = logging.getLogger("autogluon.cloud")
+        set_logger_verbosity(self.verbosity, logger=cloud_logger)
         self.local_output_path = self._setup_local_output_path(local_output_path)
         self.cloud_output_path = self._setup_cloud_output_path(cloud_output_path)
         self.backend: Backend = BackendFactory.get_backend(

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -22,7 +22,7 @@ from ..backend.constant import SAGEMAKER
 from ..endpoint.endpoint import Endpoint
 from ..utils.utils import unzip_file
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("autogluon.cloud")
 
 
 class CloudPredictor(ABC):

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -22,7 +22,7 @@ from ..backend.constant import SAGEMAKER
 from ..endpoint.endpoint import Endpoint
 from ..utils.utils import unzip_file
 
-logger = logging.getLogger("__name__")
+logger = logging.getLogger(__name__)
 
 
 class CloudPredictor(ABC):


### PR DESCRIPTION
Issue #, if available:

Description of changes:
* Logger not logging after backend extraction because file being moved around. CloudPredictor will now configure root `autogluon.cloud` logger instead.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
