### PR TITLE
predictor fit args tutorial fix

### DIFF
--- a/docs/tutorials/autogluon-cloud.md
+++ b/docs/tutorials/autogluon-cloud.md
@@ -60,7 +60,7 @@ cloud_predictor = TabularCloudPredictor(
     cloud_output_path="YOUR_S3_BUCKET_PATH"
 ).fit(
     predictor_init_args=predictor_init_args,
-    predictor_fit_args=predictor_init_args,
+    predictor_fit_args=predictor_fit_args,
     instance_type="ml.m5.2xlarge"  # Checkout supported instance and pricing here: https://aws.amazon.com/sagemaker/pricing/
     wait=True  # Set this to False to make it an unblocking call and immediately return
 )


### PR DESCRIPTION
Description of changes:

The `predictor_init_args` dict is being incorrectly used to set the `predictor_fit_args` in the `autogluon-cloud` tutorial.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
