### PR TITLE
pyyaml 6.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 - Using a fresh virtualenv, install the package via `pip3 install -e .`.
 
-- Use Python 3.7, 3.8 or 3.9 for development, as these are the versions autogluon.cloud supports.
+- Use Python versions consistent with what the package supports as defined in `setup.py` (3.8 - 3.11).
 
 - All code should adhere to the [PEP8 style](https://www.python.org/dev/peps/pep-0008/).
 

--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ install_requires = [
     # otherwise cloud module needs to be released to support new container
     "sagemaker>=2.126.0,<3.0",
     "pyarrow>=11.0,<11.1",
-    "PyYAML>=3.10,<5.4",  # awscli only support this version range
+    "PyYAML~=6.0",
     "Pillow>=9.3.0,<10.0",  # unlikely to introduce breaking changes in minor releases
     "ray[default]>=2.3.0,<2.4.0",
 ]


### PR DESCRIPTION
closes https://github.com/autogluon/autogluon-cloud/issues/90

Description of changes:

* Set pyyaml to ~=6.0
* readme update for correct python major versions. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
