### PR TITLE
Simplify TimeSeriesCloudPredictor API

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -110,7 +110,7 @@ result = cloud_predictor.predict(test_data)
 import pandas as pd
 from autogluon.cloud import TimeSeriesCloudPredictor
 
-data = pd.read_csv("https://autogluon.s3.amazonaws.com/datasets/cloud/timeseries_train.csv")
+data = pd.read_csv("https://autogluon.s3.amazonaws.com/datasets/timeseries/m4_hourly_tiny/train.csv")
 
 predictor_init_args = {
     "target": "target",

--- a/docs/index.md
+++ b/docs/index.md
@@ -111,39 +111,27 @@ import pandas as pd
 from autogluon.cloud import TimeSeriesCloudPredictor
 
 data = pd.read_csv("https://autogluon.s3.amazonaws.com/datasets/cloud/timeseries_train.csv")
-id_column="item_id"
-timestamp_column="timestamp"
-target="target"
 
 predictor_init_args = {
-    "target": target
+    "target": "target",
+    "prediction_length" : 24,
 }  # args used when creating TimeSeriesPredictor()
 predictor_fit_args = {
     "train_data": data,
-    "time_limit": 120
+    "time_limit": 120,
 }  # args passed to TimeSeriesPredictor.fit()
 cloud_predictor = TimeSeriesCloudPredictor(cloud_output_path="YOUR_S3_BUCKET_PATH")
 cloud_predictor.fit(
     predictor_init_args=predictor_init_args,
     predictor_fit_args=predictor_fit_args,
-    id_column=id_column,
-    timestamp_column=timestamp_column
+    id_column="item_id",
+    timestamp_column="timestamp",
 )
 cloud_predictor.deploy()
-result = cloud_predictor.predict_real_time(
-    test_data=data,
-    id_column=id_column,
-    timestamp_column=timestamp_column,
-    target=target
-)
+result = cloud_predictor.predict_real_time(data)
 cloud_predictor.cleanup_deployment()
 # Batch inference
-result = cloud_predictor.predict(
-    test_data=data,
-    id_column=id_column,
-    timestamp_column=timestamp_column,
-    target=target
-)
+result = cloud_predictor.predict(data)
 ```
 :::
 

--- a/tests/unittests/timeseries/test_timeseries.py
+++ b/tests/unittests/timeseries/test_timeseries.py
@@ -7,16 +7,13 @@ from autogluon.cloud import TimeSeriesCloudPredictor
 def test_timeseries(test_helper, framework_version):
     train_data = "timeseries_train.csv"
     static_features = "timeseries_static_features.csv"
-    id_column = "item_id"
-    timestamp_column = "timestamp"
-    target = "target"
     timestamp = test_helper.get_utc_timestamp_now()
     with tempfile.TemporaryDirectory() as temp_dir:
         os.chdir(temp_dir)
         test_helper.prepare_data(train_data, static_features)
         time_limit = 60
 
-        predictor_init_args = dict(target=target)
+        predictor_init_args = dict(target="target", prediction_length=3)
 
         predictor_fit_args = dict(
             train_data=train_data,
@@ -35,25 +32,15 @@ def test_timeseries(test_helper, framework_version):
             predictor_fit_args,
             train_data,
             fit_kwargs=dict(
-                id_column=id_column,
-                timestamp_column=timestamp_column,
                 static_features=static_features,
                 framework_version=framework_version,
                 custom_image_uri=training_custom_image_uri,
             ),
             deploy_kwargs=dict(framework_version=framework_version, custom_image_uri=inference_custom_image_uri),
             predict_kwargs=dict(
-                id_column=id_column,
-                timestamp_column=timestamp_column,
-                target=target,
                 static_features=static_features,
                 framework_version=framework_version,
                 custom_image_uri=inference_custom_image_uri,
             ),
-            predict_real_time_kwargs=dict(
-                id_column=id_column,
-                timestamp_column=timestamp_column,
-                target=target,
-                static_features=static_features,
-            ),
+            predict_real_time_kwargs=dict(static_features=static_features),
         )


### PR DESCRIPTION
Description of changes:
- Provide default values for `id_column` and `timestamp_column` in `TimeSeriesCloudPredictor.fit()`.
- Use values of `id_column`, `timestamp_column` and `target` provided during `fit()` when calling `predict()` and `predict_real_time()`.
    - Now `predict()` and `predict_real_time()` method do not accept `id_column` and `timestamp_column` arguments, so it's a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
