### PR TITLE
[timeseries] add persist call to timeseries serve script

### DIFF
--- a/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_serve.py
@@ -20,10 +20,10 @@ def model_fn(model_dir):
         # model already copied
         pass
     model = TimeSeriesPredictor.load(tmp_model_dir)
-    
+
     if hasattr(model, "persist"):  # timeseries added persist in v1.1
         model.persist()
-    
+
     print("MODEL LOADED")
     return model
 

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_serve.py
@@ -20,6 +20,10 @@ def model_fn(model_dir):
         # model already copied
         pass
     model = TimeSeriesPredictor.load(tmp_model_dir)
+    
+    if hasattr(model, "persist"):  # timeseries added persist in v1.1
+        model.persist()
+    
     print("MODEL LOADED")
     return model
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

`TimeSeriesPredictor.persist()` API will be added with v1.1 and is crucial for serving pretrained models in production. This PR introduces this call to the time series SM serve script.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
