### PR TITLE
Fix Framework Version Passing for test_multimodal_image_only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,8 @@ def default_setup_args(*, version):
         package_data={
             AUTOGLUON: [
                 "LICENSE",
-            ]
+            ],
+            'autogluon.cloud': ['default_cluster_configs/*.yaml'],
         },
         classifiers=[
             "Development Status :: 4 - Beta",

--- a/tests/unittests/image/test_image.py
+++ b/tests/unittests/image/test_image.py
@@ -4,7 +4,7 @@ import tempfile
 from autogluon.cloud import MultiModalCloudPredictor
 
 
-def test_multimodal_image_only(test_helper, framework_version="source"):
+def test_multimodal_image_only(test_helper, framework_version):
     train_data = "image_train_relative.csv"
     train_image = "shopee-iet.zip"
     test_data = "test_images/BabyPants_1035.jpg"


### PR DESCRIPTION
Issue #, if available:

Description of changes:
This PR addresses the issue where the `framework_version` parameter was not correctly passed to the `test_multimodal_image_only` function, leading to tests always defaulting to the "source" version. The changes ensure that the `framework_version` parameter is explicitly required and correctly utilized during the test execution.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
