### PR TITLE
Fix batch transform issue for tabular predictor with multiple partitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dmypy.json
 src/autogluon/cloud/version.py
 VERSION.minor
 .idea
+.vscode
+.DS_Store
+results.xml

--- a/src/autogluon/cloud/backend/backend.py
+++ b/src/autogluon/cloud/backend/backend.py
@@ -28,6 +28,7 @@ class Backend(ABC):
         self.local_output_path = local_output_path
         self._cloud_output_path = cloud_output_path
         self.predictor_type = predictor_type
+        self.original_features = None
 
     @abstractmethod
     def generate_default_permission(self, **kwargs) -> Dict[str, str]:

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -319,7 +319,7 @@ class SagemakerBackend(Backend):
             leaderboard=leaderboard,
         )
         # Get the label from predictor_init_args
-        label = predictor_init_args.get('label') or predictor_init_args.get('target') or None
+        label = predictor_init_args.get("label") or predictor_init_args.get("target") or None
         if image_column is not None:
             ag_args["image_column"] = image_column
         ag_args_path = os.path.join(self.local_output_path, "utils", "ag_args.pkl")
@@ -1189,9 +1189,6 @@ class SagemakerBackend(Backend):
             else:
                 test_data = load_pd.load(test_data)
 
-        # Ensure columns are in sync with model expectations for tabular use cases
-        # TODO: Add support for other modalities once features are exposed in APIs
-        # Tracking at https://github.com/autogluon/autogluon/issues/4477
         if isinstance(test_data, pd.DataFrame) and original_features is not None:
             expected_columns = original_features
             incoming_columns = test_data.columns.tolist()

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -1006,6 +1006,8 @@ class SagemakerBackend(Backend):
                 )
 
         train_input = train_data
+        if isinstance(train_data, str):
+            train_data = load_pd.load(train_data)
         self.original_features = [col for col in train_data.columns if col != label]
         train_data = self._prepare_data(train_data, "train")
         logger.log(20, "Uploading train data...")

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -902,7 +902,7 @@ class SagemakerBackend(Backend):
             model_kwargs=model_kwargs,
             transformer_kwargs=transformer_kwargs,
             transform_kwargs=transform_kwargs,
-            local_predictor=local_predictor, 
+            local_predictor=local_predictor,
         )
 
         if include_predict:
@@ -1112,7 +1112,6 @@ class SagemakerBackend(Backend):
             raise e
 
     def _upload_batch_predict_data(self, test_data, bucket, key_prefix):
-
         if isinstance(test_data, pd.DataFrame):
             test_data = self._prepare_data(test_data, "test", output_type="csv")
         logger.log(20, "Uploading data...")

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -1183,7 +1183,9 @@ class SagemakerBackend(Backend):
         if isinstance(test_data, str) and not os.path.isdir(test_data):
             # either a file to a dataframe, or a file to an image
             if is_image_file(test_data):
-                raise ValueError("Image file is not supported for batch inference")
+                logger.warning(
+                    "Are you sure you want to do batch inference on a single image? You might want to try `deploy()` and `predict_real_time()` instead"
+                )
             else:
                 test_data = load_pd.load(test_data)
 

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -622,6 +622,7 @@ class CloudPredictor(ABC):
         if backend_kwargs is None:
             backend_kwargs = {}
         backend_kwargs = self.backend.parse_backend_predict_kwargs(backend_kwargs)
+        local_predictor = self.to_local_predictor()
         return self.backend.predict(
             test_data=test_data,
             test_data_image_column=test_data_image_column,
@@ -631,6 +632,7 @@ class CloudPredictor(ABC):
             instance_type=instance_type,
             instance_count=instance_count,
             custom_image_uri=custom_image_uri,
+            local_predictor=local_predictor,
             wait=wait,
             **backend_kwargs,
         )
@@ -719,6 +721,10 @@ class CloudPredictor(ABC):
         if backend_kwargs is None:
             backend_kwargs = {}
         backend_kwargs = self.backend.parse_backend_predict_kwargs(backend_kwargs)
+        local_predictor = None
+        #TODO add support for multimodal and timeseries as this is needed for batch inference see issue #136
+        if self.predictor_type == "tabular":
+            local_predictor = self.to_local_predictor()
         return self.backend.predict_proba(
             test_data=test_data,
             test_data_image_column=test_data_image_column,
@@ -729,6 +735,7 @@ class CloudPredictor(ABC):
             instance_type=instance_type,
             instance_count=instance_count,
             custom_image_uri=custom_image_uri,
+            local_predictor=local_predictor,  # Only pass for tabular predictor
             wait=wait,
             **backend_kwargs,
         )

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -622,7 +622,6 @@ class CloudPredictor(ABC):
         if backend_kwargs is None:
             backend_kwargs = {}
         backend_kwargs = self.backend.parse_backend_predict_kwargs(backend_kwargs)
-        local_predictor = self.to_local_predictor()
         return self.backend.predict(
             test_data=test_data,
             test_data_image_column=test_data_image_column,
@@ -632,7 +631,6 @@ class CloudPredictor(ABC):
             instance_type=instance_type,
             instance_count=instance_count,
             custom_image_uri=custom_image_uri,
-            local_predictor=local_predictor,
             wait=wait,
             **backend_kwargs,
         )

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -722,7 +722,7 @@ class CloudPredictor(ABC):
             backend_kwargs = {}
         backend_kwargs = self.backend.parse_backend_predict_kwargs(backend_kwargs)
         local_predictor = None
-        #TODO add support for multimodal and timeseries as this is needed for batch inference see issue #136
+        # TODO add support for multimodal and timeseries as this is needed for batch inference see issue #136
         if self.predictor_type == "tabular":
             local_predictor = self.to_local_predictor()
         return self.backend.predict_proba(

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -719,10 +719,6 @@ class CloudPredictor(ABC):
         if backend_kwargs is None:
             backend_kwargs = {}
         backend_kwargs = self.backend.parse_backend_predict_kwargs(backend_kwargs)
-        local_predictor = None
-        # TODO add support for multimodal and timeseries as this is needed for batch inference see issue #136
-        if self.predictor_type == "tabular":
-            local_predictor = self.to_local_predictor()
         return self.backend.predict_proba(
             test_data=test_data,
             test_data_image_column=test_data_image_column,
@@ -733,7 +729,6 @@ class CloudPredictor(ABC):
             instance_type=instance_type,
             instance_count=instance_count,
             custom_image_uri=custom_image_uri,
-            local_predictor=local_predictor,  # Only pass for tabular predictor
             wait=wait,
             **backend_kwargs,
         )

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
@@ -44,8 +44,6 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
     if input_content_type == "application/x-parquet":
         buf = BytesIO(request_body)
         data = pd.read_parquet(buf)
-
-        # Reorder columns or assign expected columns if necessary
         data = _align_columns(data, column_names)
 
     elif input_content_type == "text/csv":
@@ -80,6 +78,10 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
     if image_column is not None:
         print(f"Detected image column {image_column}")
         data[image_column] = [_save_image_and_update_dataframe_column(bytes) for bytes in data[image_column]]
+
+    # Ensure inference_kwargs is a dictionary
+    if inference_kwargs is None:
+        inference_kwargs = {}
 
     # Make predictions
     if model.problem_type not in [REGRESSION, QUANTILE]:

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
@@ -79,7 +79,7 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         print(f"Detected image column {image_column}")
         data[image_column] = [_save_image_and_update_dataframe_column(bytes) for bytes in data[image_column]]
 
-    # Ensure inference_kwargs is a dictionary
+    # Ensure inference_kwargs is a dictionary right before use
     if inference_kwargs is None:
         inference_kwargs = {}
 

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
@@ -58,9 +58,7 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
 
     elif input_content_type == "application/jsonl":
         buf = StringIO(request_body)
-        data = _read_with_fallback(
-            lambda b: pd.read_json(b, orient="records", lines=True), buf, column_names
-        )
+        data = _read_with_fallback(lambda b: pd.read_json(b, orient="records", lines=True), buf, column_names)
 
     elif input_content_type == "application/x-autogluon":
         buf = bytes(request_body)

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
@@ -40,60 +40,50 @@ def model_fn(model_dir):
 
 def transform_fn(model, request_body, input_content_type, output_content_type="application/json"):
     inference_kwargs = {}
+
     if input_content_type == "application/x-parquet":
         buf = BytesIO(request_body)
         data = pd.read_parquet(buf)
 
+        # Reorder columns or assign expected columns if necessary
+        data = _align_columns(data, column_names)
+
     elif input_content_type == "text/csv":
         buf = StringIO(request_body)
-        data = pd.read_csv(buf)
+        data = _read_with_fallback(pd.read_csv, buf, column_names)
 
     elif input_content_type == "application/json":
         buf = StringIO(request_body)
-        data = pd.read_json(buf)
+        data = _read_with_fallback(pd.read_json, buf, column_names)
 
     elif input_content_type == "application/jsonl":
         buf = StringIO(request_body)
-        data = pd.read_json(buf, orient="records", lines=True)
+        data = _read_with_fallback(
+            lambda b: pd.read_json(b, orient="records", lines=True), buf, column_names
+        )
 
     elif input_content_type == "application/x-autogluon":
         buf = bytes(request_body)
         payload = pickle.loads(buf)
         data = pd.read_parquet(BytesIO(payload["data"]))
-        inference_kwargs = payload["inference_kwargs"]
-        if inference_kwargs is None:
-            inference_kwargs = {}
+        inference_kwargs = payload.get("inference_kwargs", {})
+        data = _align_columns(data, column_names)
 
     else:
         raise ValueError(f"{input_content_type} input content type not supported.")
 
-    test_columns = sorted(list(data.columns))
-    train_columns = sorted(column_names)
-    if test_columns != train_columns:
-        num_cols = len(data.columns)
-
-        if num_cols != len(column_names):
-            raise Exception(
-                f"Invalid data format. Input data has {num_cols} while the model expects {len(column_names)}"
-            )
-
-        else:
-            new_row = pd.DataFrame(data.columns).transpose()
-            old_rows = pd.DataFrame(data.values)
-            data = pd.concat([new_row, old_rows]).reset_index(drop=True)
-            data.columns = column_names
-
-    # find image column
+    # Find and process image column if present
     image_column = None
     for column_name, special_types in model.feature_metadata.get_type_map_special().items():
         if "image_path" in special_types:
             image_column = column_name
             break
-    # save image column bytes to disk and update the column with saved path
+
     if image_column is not None:
         print(f"Detected image column {image_column}")
         data[image_column] = [_save_image_and_update_dataframe_column(bytes) for bytes in data[image_column]]
 
+    # Make predictions
     if model.problem_type not in [REGRESSION, QUANTILE]:
         pred_proba = model.predict_proba(data, as_pandas=True, **inference_kwargs)
         pred = get_pred_from_proba_df(pred_proba, problem_type=model.problem_type)
@@ -102,20 +92,82 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         prediction = pd.concat([pred, pred_proba], axis=1)
     else:
         prediction = model.predict(data, as_pandas=True, **inference_kwargs)
+
     if isinstance(prediction, pd.Series):
         prediction = prediction.to_frame()
 
+    # Format output
+    output_content_type = output_content_type.lower()
     if "application/x-parquet" in output_content_type:
         prediction.columns = prediction.columns.astype(str)
-        output = prediction.to_parquet()
+        output = prediction.to_parquet(index=False)
         output_content_type = "application/x-parquet"
     elif "application/json" in output_content_type:
-        output = prediction.to_json()
+        output = prediction.to_json(orient="records")
         output_content_type = "application/json"
     elif "text/csv" in output_content_type:
-        output = prediction.to_csv(index=None)
+        output = prediction.to_csv(index=False)
         output_content_type = "text/csv"
     else:
         raise ValueError(f"{output_content_type} content type not supported")
 
     return output, output_content_type
+
+
+def _read_with_fallback(read_func, buf, expected_columns):
+    """
+    Attempts to read data with headers. If columns don't match expected_columns,
+    re-reads without headers and assigns expected_columns.
+
+    Parameters
+    ----------
+    read_func : callable
+        Function to read the data (e.g., pd.read_csv, pd.read_json).
+    buf : IO buffer
+        Buffer containing the data.
+    expected_columns : list
+        List of expected column names.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns aligned to expected_columns.
+    """
+    # Attempt to read with headers
+    data = read_func(buf)
+    if set(data.columns) != set(expected_columns):
+        # Reset buffer and read without headers
+        buf.seek(0)
+        data = read_func(buf, header=None)
+        # Assign expected column names
+        data.columns = expected_columns
+    else:
+        # Reorder columns to match expected_columns
+        data = data[expected_columns]
+    return data
+
+
+def _align_columns(data, expected_columns):
+    """
+    Aligns DataFrame columns to expected_columns.
+    Removes extra columns and reorders existing ones.
+
+    Parameters
+    ----------
+    data : pd.DataFrame
+        Input DataFrame.
+    expected_columns : list
+        List of expected column names.
+
+    Returns
+    -------
+    pd.DataFrame
+        DataFrame with columns aligned to expected_columns.
+    """
+    if set(data.columns) != set(expected_columns):
+        missing_columns = set(expected_columns) - set(data.columns)
+        if missing_columns:
+            raise ValueError(f"Missing columns in input data: {missing_columns}")
+    # Remove extra columns and reorder
+    data = data[expected_columns]
+    return data


### PR DESCRIPTION


### Description:
This PR fixes the issue where batch transform jobs fail due to column misalignment when the input CSV file is partitioned into multiple records. The problem arises because headers from different partitions are not handled properly, leading to misaligned columns and prediction failures during inference.

**Changes:**
- Added logic to align columns across partitions by ensuring headers are managed correctly.
- Introduced `_read_with_fallback` and `_align_columns` helper functions to handle column alignment.
- Updated `transform_fn` in `tabular_serve.py` to use these helper functions.

**Limitations:**
- This fix currently only works for the tabular predictor. Support for multimodal and timeseries predictors depends on the implementation of `original_features`, which can be tracked in [issue #4477](https://github.com/autogluon/autogluon/issues/4477).

**Steps to Reproduce:**
The following script can be used to reproduce the issue:

```python
from autogluon.cloud import TabularCloudPredictor
import pandas as pd

# Load datasets
train_data = pd.read_csv("https://autogluon.s3.amazonaws.com/datasets/Inc/train.csv")
test_data = pd.read_csv("https://autogluon.s3.amazonaws.com/datasets/Inc/test.csv")
test_data.drop(columns=['class'], inplace=True)

# Cloud Predictor Arguments
predictor_init_args = {"label": "class"}  
predictor_fit_args = {"train_data": train_data, "time_limit": 60}  

# Initialize Cloud Predictor and Fit
cloud_predictor = TabularCloudPredictor(cloud_output_path='tonyhu-autogluon')
cloud_predictor.fit(predictor_init_args=predictor_init_args, predictor_fit_args=predictor_fit_args)

# Batch Inference with small max_payload to force multiple partitions
result = cloud_predictor.predict(test_data, backend_kwargs={"transformer_kwargs": {"max_payload": 1}})
```

**Expected Behavior:**
The batch transform job should handle multiple partitions correctly, aligning columns across the partitions and ignoring or managing headers if present in individual partitions.

**Observed Behavior:**
The job fails with the following error logs:
```
Bad HTTP status received from algorithm: 500
invalid literal for int() with base 10: '0.1': Error while type casting for column 'capital-loss'
```

Logs show that the columns are misaligned for certain partitions:
```
test_columns: [' 11th', ' Machine-op-inspct', ' Male', ' Never-married', ' Other-relative', ' Private', ' United-States', ' White', '0', '0.1', '207443', '50', '62', '7']
2024-09-13T21:56:19,062 [INFO ] W-9000-model_1.0-stdout MODEL_LOG - train_columns: ['age', 'capital-gain', 'capital-loss', 'education', 'education-num', 'fnlwgt', 'hours-per-week', 'marital-status', 'native-country', 'occupation', 'race', 'relationship', 'sex', 'workclass']
```

**Environment:**
- `autogluon==1.1.0`
- Running batch transform in SageMaker with `MultiRecord` strategy.
- `MaxPayloadInMB=1` is set to ensure multiple partitions.

**Additional Information:**
The issue seems to be that AutoGluon Cloud is not handling the headers properly when dealing with batch transform partitioned records. In a multi-partition job, not all batches will have the header/column, which is causing the column misalignment.

**Note:**
This fix currently only works for the tabular predictor. Support for multimodal and timeseries predictors depends on the implementation of `original_features`, which can be tracked in [issue #4477](https://github.com/autogluon/autogluon/issues/4477).