### PR TITLE
Fix CodeQL workflow permissions for Dependabot branches

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,9 @@ name: "Code scanning - action"
 
 on:
   push:
+    # Exclude Dependabot branches from triggering on push
+    branches-ignore:
+      - 'dependabot/**'
   pull_request:
   schedule:
     - cron: '0 19 * * 0'


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Exclude Dependabot branches from triggering on push events
- Ensure CodeQL analysis runs on pull_request events for Dependabot

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
