### PR TITLE
Update timeseries_cloud_predictor.py

### DIFF
--- a/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
@@ -182,6 +182,7 @@ class TimeSeriesCloudPredictor(CloudPredictor):
             target=self.target_column,
             static_features=static_features,
             accept=accept,
+            **kwargs
         )
 
     def predict_proba_real_time(self, **kwargs) -> pd.DataFrame:


### PR DESCRIPTION
Issue #116

Description of changes:
Simply pass through **kwargs from the method call to its internal method call, which will allow passing through inference_kwargs that may be required for inference (for example future_covariates).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
