### PR TITLE
Replace persist_models with persist call due to API deprecation

### DIFF
--- a/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
@@ -32,7 +32,7 @@ def _save_image_and_update_dataframe_column(bytes):
 def model_fn(model_dir):
     """loads model from previously saved artifact"""
     model = TabularPredictor.load(model_dir)
-    model.persist_models()
+    model.persist()
     globals()["column_names"] = model.original_features
 
     return model

--- a/tests/unittests/tabular/test_tabular.py
+++ b/tests/unittests/tabular/test_tabular.py
@@ -68,5 +68,5 @@ def test_tabular_tabular_text_image(test_helper, framework_version):
         local_predictor = cloud_predictor.to_local_predictor(
             require_version_match=False, require_py_version_match=False
         )
-        models = local_predictor.get_model_names()
+        models = local_predictor.model_names()
         assert "ImagePredictor" in models


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
`persist_models` API is being deprecated as part of 1.2 [release](https://github.com/autogluon/autogluon/blob/master/tabular/src/autogluon/tabular/predictor/_deprecated_methods.py#L15). This PR is intended to migrate to the new API to avoid errors at the time of inference

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
