### PR TITLE
[bug fix] Fix the time series target, timestamp and id column issue for attach_job call

### DIFF
--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -26,7 +26,10 @@ from ..utils.ag_sagemaker import (
 from ..utils.aws_utils import setup_sagemaker_session
 from ..utils.constants import CLOUD_RESOURCE_PREFIX, VALID_ACCEPT
 from ..utils.dlc_utils import parse_framework_version
-from ..utils.iam import replace_iam_policy_place_holder, replace_trust_relationship_place_holder
+from ..utils.iam import (
+    replace_iam_policy_place_holder,
+    replace_trust_relationship_place_holder,
+)
 from ..utils.misc import MostRecentInsertedOrderedDict
 from ..utils.sagemaker_iam import (
     SAGEMAKER_CLOUD_POLICY,

--- a/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
@@ -320,8 +320,6 @@ class TimeSeriesCloudPredictor(CloudPredictor):
             self.id_column = metadata.get("id_column")
             self.timestamp_column = metadata.get("timestamp_column")
             self.target_column = metadata.get("target_column")
-            if "static_features" in metadata:
-            self.static_features = json.loads(metadata.get("static_features", None))
         else:
             logger.warning(
                 "No predictor metadata found in training job. Please set id_column, timestamp_column and target_column manually."

--- a/tests/unittests/timeseries/test_timeseries.py
+++ b/tests/unittests/timeseries/test_timeseries.py
@@ -14,22 +14,29 @@ def test_timeseries(test_helper, framework_version):
         time_limit = 60
 
         predictor_init_args = dict(target="target", prediction_length=3)
-
         predictor_fit_args = dict(
             train_data=train_data,
             presets="medium_quality",
             time_limit=time_limit,
         )
+
         cloud_predictor = TimeSeriesCloudPredictor(
             cloud_output_path=f"s3://autogluon-cloud-ci/test-timeseries/{framework_version}/{timestamp}",
             local_output_path="test_timeseries_cloud_predictor",
         )
+        cloud_predictor_no_train = TimeSeriesCloudPredictor(
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-timeseries-no-train/{framework_version}/{timestamp}",
+            local_output_path="test_timeseries_cloud_predictor_no_train",
+        )
+
         training_custom_image_uri = test_helper.get_custom_image_uri(framework_version, type="training", gpu=False)
         inference_custom_image_uri = test_helper.get_custom_image_uri(framework_version, type="inference", gpu=False)
-        test_helper.test_basic_functionality(
+
+        test_helper.test_functionality(
             cloud_predictor,
             predictor_init_args,
             predictor_fit_args,
+            cloud_predictor_no_train,
             train_data,
             fit_kwargs=dict(
                 static_features=static_features,


### PR DESCRIPTION
Issue #165

Description of changes:
- Fixed TimeSeriesCloudPredictor `attach_job()` functionality to properly restore id_column, timestamp_column and target_column attributes from training job metadata
- Added predictor metadata serialization during fit() to store these attributes
- Modified `SageMakerFitJob` to properly handle `predictor_metadata` in hyperparameters

The fix allows TimeSeriesCloudPredictor to work properly after attach_job() without manual attribute setting

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.