### PR TITLE
Merge kwargs for fit and deploy Sagemaker methods

### DIFF
--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -489,19 +489,20 @@ class SagemakerBackend(Backend):
         else:
             model_kwargs_env = {SAGEMAKER_MODEL_SERVER_WORKERS: "1"}
 
-        model = model_cls(
-            model_data=predictor_path,
-            role=self.role_arn,
-            region=self._region,
-            framework_version=framework_version,
-            py_version=py_version,
-            instance_type=instance_type,
-            custom_image_uri=custom_image_uri,
-            entry_point=entry_point,
-            predictor_cls=predictor_cls,
-            env=model_kwargs_env,
+        merged_model_kwargs = {
+            "model_data": predictor_path,
+            "role": self.role_arn,
+            "region": self._region,
+            "framework_version": framework_version,
+            "py_version": py_version,
+            "instance_type": instance_type,
+            "custom_image_uri": custom_image_uri,
+            "entry_point": entry_point,
+            "predictor_cls": predictor_cls,
+            "env": model_kwargs_env,
             **model_kwargs,
-        )
+        }
+        model = model_cls(**merged_model_kwargs)
         if deploy_kwargs is None:
             deploy_kwargs = {}
 

--- a/src/autogluon/cloud/job/sagemaker_job.py
+++ b/src/autogluon/cloud/job/sagemaker_job.py
@@ -199,21 +199,26 @@ class SageMakerFitJob(SageMakerJob):
         **kwargs,
     ):
         self._local_mode = instance_type in (LOCAL_MODE, LOCAL_MODE_GPU)
-        sagemaker_estimator = AutoGluonSagemakerEstimator(
-            role=role,
-            entry_point=entry_point,
-            region=region,
-            instance_type=instance_type,
-            instance_count=instance_count,
-            volume_size=volume_size,
-            framework_version=framework_version,
-            py_version=py_version,
-            base_job_name=base_job_name,
-            output_path=output_path,
-            code_location=code_location,
-            image_uri=custom_image_uri,
+
+        merged_kwargs = {
+            "role": role,
+            "entry_point": entry_point,
+            "region": region,
+            "instance_type": instance_type,
+            "instance_count": instance_count,
+            "volume_size": volume_size,
+            "framework_version": framework_version,
+            "py_version": py_version,
+            "base_job_name": base_job_name,
+            "output_path": output_path,
+            "code_location": code_location,
+            "image_uri": custom_image_uri,
             **autogluon_sagemaker_estimator_kwargs,
+        }
+        sagemaker_estimator = AutoGluonSagemakerEstimator(
+            **merged_kwargs
         )
+
         logger.log(20, f"Start sagemaker training job `{job_name}`")
         try:
             sagemaker_estimator.fit(inputs=inputs, wait=wait, job_name=job_name, **kwargs)


### PR DESCRIPTION
Issue #, if available: https://github.com/autogluon/autogluon-cloud/issues/182

Description of changes: Merge the arguments to avoid double-defining properties like `role` (as an argument and as kwarg).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.