### PR TITLE
Add autogluon-cloud python setup API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ dmypy.json
 
 src/autogluon/cloud/version.py
 VERSION.minor
+src/autogluon/cloud/templates/*.yaml
 .idea
 .vscode
 .DS_Store

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 
 from setuptools import setup
 
@@ -14,6 +15,25 @@ def create_version_file(*, version):
     with open(version_path, "w") as f:
         f.write(f'"""This is the {AUTOGLUON}.{CLOUD} version file."""\n')
         f.write("__version__ = '{}'\n".format(version))
+
+
+def sync_templates():
+    """Copy canonical CloudFormation templates into the package so they ship in the wheel.
+
+    The templates at repo-root `/cloudformation/` are the source of truth (referenced
+    from docs by public URL). At build time we mirror them under the `autogluon.cloud`
+    package so `importlib.resources` can locate them at runtime without depending on the
+    repo layout.
+    """
+    src_dir = "cloudformation"
+    dst_dir = os.path.join("src", AUTOGLUON, CLOUD, "templates")
+    if not os.path.isdir(src_dir):
+        # Building from an sdist that already has the copies — nothing to do.
+        return
+    os.makedirs(dst_dir, exist_ok=True)
+    for filename in os.listdir(src_dir):
+        if filename.endswith(".yaml"):
+            shutil.copyfile(os.path.join(src_dir, filename), os.path.join(dst_dir, filename))
 
 
 def update_version(version, use_file_if_exists=True, create_file=False):
@@ -64,7 +84,11 @@ def default_setup_args(*, version):
         include_package_data=True,
         python_requires=PYTHON_REQUIRES,
         package_data={
-            "autogluon.cloud": ["default_cluster_configs/*.yaml", "utils/autogluon_dlc.json"],
+            "autogluon.cloud": [
+                "default_cluster_configs/*.yaml",
+                "utils/autogluon_dlc.json",
+                "templates/*.yaml",
+            ],
         },
         classifiers=[
             "Development Status :: 4 - Beta",
@@ -136,6 +160,7 @@ extras_require["tests"] = test_requirements
 
 if __name__ == "__main__":
     create_version_file(version=version)
+    sync_templates()
     setup_args = default_setup_args(version=version)
     setup(
         install_requires=install_requires,

--- a/src/autogluon/cloud/__init__.py
+++ b/src/autogluon/cloud/__init__.py
@@ -1,5 +1,15 @@
 from autogluon.common.utils.log_utils import _add_stream_handler
 
+from .cloud_setup import initialize, status, teardown
 from .predictor import MultiModalCloudPredictor, TabularCloudPredictor, TimeSeriesCloudPredictor
 
 _add_stream_handler()
+
+__all__ = [
+    "MultiModalCloudPredictor",
+    "TabularCloudPredictor",
+    "TimeSeriesCloudPredictor",
+    "initialize",
+    "status",
+    "teardown",
+]

--- a/src/autogluon/cloud/__init__.py
+++ b/src/autogluon/cloud/__init__.py
@@ -1,6 +1,6 @@
 from autogluon.common.utils.log_utils import _add_stream_handler
 
-from .cloud_setup import initialize, status, teardown
+from .cloud_setup import bootstrap, register, status, teardown
 from .predictor import MultiModalCloudPredictor, TabularCloudPredictor, TimeSeriesCloudPredictor
 
 _add_stream_handler()
@@ -9,7 +9,8 @@ __all__ = [
     "MultiModalCloudPredictor",
     "TabularCloudPredictor",
     "TimeSeriesCloudPredictor",
-    "initialize",
+    "bootstrap",
+    "register",
     "status",
     "teardown",
 ]

--- a/src/autogluon/cloud/backend/constant.py
+++ b/src/autogluon/cloud/backend/constant.py
@@ -5,3 +5,6 @@ TIMESERIES_SAGEMAKER = "timeseries_sagemaker"
 RAY = "ray"
 RAY_AWS = "ray_aws"
 TABULAR_RAY_AWS = "tabular_ray_aws"
+
+# Backends the top-level setup API can provision via CloudFormation.
+SUPPORTED_SETUP_BACKENDS = (SAGEMAKER, RAY_AWS)

--- a/src/autogluon/cloud/backend/constant.py
+++ b/src/autogluon/cloud/backend/constant.py
@@ -7,4 +7,4 @@ RAY_AWS = "ray_aws"
 TABULAR_RAY_AWS = "tabular_ray_aws"
 
 # Backends the top-level setup API can provision via CloudFormation.
-SUPPORTED_SETUP_BACKENDS = (SAGEMAKER, RAY_AWS)
+SUPPORTED_BACKENDS = (SAGEMAKER, RAY_AWS)

--- a/src/autogluon/cloud/cloud_setup.py
+++ b/src/autogluon/cloud/cloud_setup.py
@@ -2,162 +2,190 @@
 
 Usage::
 
-    import autogluon.cloud as agc
+    from autogluon.cloud import bootstrap, register, status, teardown
 
-    agc.initialize(backend="sagemaker", region="us-east-1")   # deploy CFN + save config
-    agc.initialize(role_arn=..., bucket=...)                  # save config, skip CFN
-    agc.status()                                             # dict of health checks
-    agc.teardown(delete_bucket_contents=True)                # delete CFN + config
+    bootstrap()                                          # deploy CFN + save config
+    register(role_arn=..., bucket=..., region=...)       # save existing resources
+    status()                                             # dict of health checks
+    teardown(delete_bucket_contents=True)                # delete CFN + config
 """
 
 from __future__ import annotations
 
-import typing
 from importlib import resources
 from typing import Any, Dict, Literal, Optional
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
 
+from .backend.constant import RAY_AWS, SAGEMAKER, SUPPORTED_SETUP_BACKENDS
 from .config import (
-    Profile,
-    delete_profile,
+    CloudConfig,
+    delete_config,
     get_config_path,
     load_config,
-    upsert_profile,
+    save_config,
 )
 
-__all__ = ["initialize", "status", "teardown"]
+__all__ = ["bootstrap", "register", "status", "teardown"]
 
-Backend = Literal["sagemaker", "ray_aws"]
-_SUPPORTED_BACKENDS = typing.get_args(Backend)
+BackendName = Literal[SAGEMAKER, RAY_AWS]
 
 
-def initialize(
+def bootstrap(
     *,
-    backend: Backend = "sagemaker",
-    region: Optional[str] = None,
+    backend: BackendName = "sagemaker",
     stack_name: Optional[str] = None,
-    role_arn: Optional[str] = None,
-    bucket: Optional[str] = None,
-    aws_profile: Optional[str] = None,
-    profile_name: str = "default",
+    session: Optional[boto3.Session] = None,
 ) -> None:
-    """Provision AG-Cloud resources and save a config profile.
+    """Deploy the CloudFormation stack and persist resource identifiers.
 
-    Either deploy a CloudFormation stack (creates an IAM role + S3 bucket
-    from scratch) or persist pre-existing resources — pass ``role_arn`` and
-    ``bucket`` together to skip CloudFormation. The persisted profile is the
-    canonical record; call :func:`status` to inspect it.
+    On completion the IAM role and S3 bucket created by the stack are saved
+    to ``~/.autogluon/cloud.yaml`` via :func:`register`. If you
+    already have an IAM role and bucket in place, call :func:`register`
+    directly and skip this function entirely.
 
     Parameters
     ----------
     backend
         Which AG-Cloud backend to provision.
-    region
-        AWS region. Falls back to the boto3-configured region, then ``us-east-1``.
     stack_name
         CloudFormation stack name. Auto-generated as ``ag-cloud-<backend>``
         if not given.
-    role_arn, bucket
-        If BOTH are given, skip CloudFormation and record these pre-existing
-        resources.
-    aws_profile
-        Local AWS profile name (from ``~/.aws/credentials`` or SSO) to use as
-        the base identity. Defaults to the standard boto3 credential chain.
-    profile_name
-        Name of the AG-Cloud profile entry in ``~/.autogluon/cloud.yaml``.
+    session
+        A ``boto3.Session`` to use for AWS calls. If ``None``, a default
+        session is constructed from the standard credential chain
+        (env vars, ``~/.aws/credentials``, SSO, instance profile).
 
     Raises
     ------
     ValueError
-        If ``role_arn`` and ``bucket`` aren't both provided together, or if
-        an unknown backend is passed.
+        If an unknown backend is passed.
     RuntimeError
         If AWS credentials can't be detected.
     """
-    if (role_arn is None) ^ (bucket is None):
-        raise ValueError("`role_arn` and `bucket` must be provided together.")
-    if backend not in _SUPPORTED_BACKENDS:
-        raise ValueError(f"Unsupported backend {backend!r}. Choose from {_SUPPORTED_BACKENDS}.")
+    if backend not in SUPPORTED_SETUP_BACKENDS:
+        raise ValueError(f"Unsupported backend {backend!r}. Choose from {SUPPORTED_SETUP_BACKENDS}.")
 
-    session = _verified_session(aws_profile=aws_profile, region=region)
-    region = session.region_name or "us-east-1"
+    session, account = _verified_session(session)
+    region = session.region_name
+    if region is None:
+        raise RuntimeError(
+            "AWS region not configured. Set AWS_DEFAULT_REGION, run `aws configure`, "
+            "or pass `session=boto3.Session(region_name=...)`."
+        )
+    stack_name = stack_name or f"ag-cloud-{backend.replace('_', '-')}"
 
-    if role_arn is None:
-        stack_name = stack_name or f"ag-cloud-{backend.replace('_', '-')}"
-        print(f"Deploying CloudFormation stack {stack_name!r} (this typically takes ~1 minute)...")
-        role_arn, bucket = _provision_stack(session, stack_name=stack_name, backend=backend)
-        print(f"Stack {stack_name!r} deployed.")
+    print(f"Deploying CloudFormation stack {stack_name!r} (account {account}, region {region}, ~1 minute)...")
+    role_arn, bucket = _provision_stack(session, stack_name=stack_name, backend=backend)
+    print(f"Stack {stack_name!r} deployed.")
 
-    profile = Profile(
+    register(
+        role_arn=role_arn,
+        bucket=bucket,
+        region=region,
+        backend=backend,
+        stack_name=stack_name,
+    )
+
+
+def register(
+    *,
+    role_arn: str,
+    bucket: str,
+    region: str,
+    backend: BackendName = "sagemaker",
+    stack_name: Optional[str] = None,
+) -> None:
+    """Persist resource identifiers to ``~/.autogluon/cloud.yaml``.
+
+    Use this when you already have an IAM role and S3 bucket — for example,
+    centrally provisioned by your platform team — and just want AG-Cloud to
+    remember them. Pure file I/O; no AWS calls.
+
+    Parameters
+    ----------
+    role_arn
+        ARN of an IAM role suitable for SageMaker / Ray to assume.
+    bucket
+        S3 bucket name where AG-Cloud will read/write artifacts.
+    region
+        AWS region for AG-Cloud operations.
+    backend
+        Which AG-Cloud backend the resources are intended for.
+    stack_name
+        Optional CloudFormation stack name. If you deployed the resources
+        via your own CFN stack and want :func:`teardown` to be able to
+        delete it later, pass the name here. Defaults to ``None``, meaning
+        teardown will only remove the config file, not touch AWS.
+
+    Raises
+    ------
+    ValueError
+        If an unknown backend is passed.
+    """
+    if backend not in SUPPORTED_SETUP_BACKENDS:
+        raise ValueError(f"Unsupported backend {backend!r}. Choose from {SUPPORTED_SETUP_BACKENDS}.")
+    config = CloudConfig(
         region=region,
         role_arn=role_arn,
         bucket=bucket,
         backend=backend,
         stack_name=stack_name,
-        aws_profile=aws_profile,
     )
-    upsert_profile(profile_name, profile)
-    print(f"Saved profile {profile_name!r} to {get_config_path()}")
+    save_config(config)
+    print(f"Saved AG-Cloud config to {get_config_path()}")
 
 
-def status(profile_name: Optional[str] = None, *, check_role: bool = True) -> Dict[str, Any]:
-    """Return a health snapshot of the named (or active) profile.
+def status(
+    *,
+    session: Optional[boto3.Session] = None,
+    check_role: bool = True,
+) -> Dict[str, Any]:
+    """Return a health snapshot of the persisted config.
 
-    On found=True the dict contains ``profile`` (Profile), ``is_active`` (bool),
-    ``config_path`` (str), and ``checks`` (dict of ``bucket`` / ``stack`` /
-    ``role`` strings, each ``"ok"`` or a failure description).
+    On found=True the dict contains ``config`` (CloudConfig), ``config_path``
+    (str), and ``checks`` (dict of ``bucket`` / ``stack`` / ``role`` strings,
+    each ``"ok"`` or a failure description).
 
-    On found=False the dict contains ``config_path`` and (if a profile name
-    was given but missing) ``reason`` and ``available_profiles``.
+    On found=False the dict contains just ``config_path``.
 
     Makes real AWS calls. Pass ``check_role=False`` to skip ``iam:GetRole``.
+    Pass ``session=`` to use specific credentials; otherwise the standard
+    boto3 credential chain is used (with the saved region as a default).
     """
     config = load_config()
-    if config is None or not config.profiles:
+    if config is None:
         return {"found": False, "config_path": str(get_config_path())}
 
-    try:
-        profile = config.get_profile(profile_name)
-    except KeyError:
-        return {
-            "found": False,
-            "config_path": str(get_config_path()),
-            "reason": "profile not found",
-            "requested_profile": profile_name,
-            "available_profiles": sorted(config.profiles),
-        }
-    active = profile_name or config.active_profile
-
-    session = _boto_session(aws_profile=profile.aws_profile, region=profile.region)
-    checks: Dict[str, str] = {"bucket": _check_bucket(session, profile.bucket)}
-    if profile.stack_name:
-        checks["stack"] = _check_stack(session, profile.stack_name)
+    session = session or boto3.Session(region_name=config.region)
+    checks: Dict[str, str] = {"bucket": _check_bucket(session, config.bucket)}
+    if config.stack_name:
+        checks["stack"] = _check_stack(session, config.stack_name)
     if check_role:
-        checks["role"] = _check_role(session, profile.role_arn)
+        checks["role"] = _check_role(session, config.role_arn)
 
     return {
         "found": True,
         "config_path": str(get_config_path()),
-        "profile_name": active,
-        "is_active": active == config.active_profile,
-        "profile": profile,
+        "config": config,
         "checks": checks,
     }
 
 
 def teardown(
-    profile_name: Optional[str] = None,
     *,
+    session: Optional[boto3.Session] = None,
     delete_bucket_contents: bool = False,
 ) -> None:
-    """Delete the CloudFormation stack and remove the profile from config.
+    """Delete the CloudFormation stack (if any) and remove the config file.
 
     Parameters
     ----------
-    profile_name
-        Profile to tear down. Defaults to the active profile.
+    session
+        A ``boto3.Session`` to use for AWS calls. If ``None``, a default
+        session is built from the standard credential chain, with the saved
+        region applied automatically.
     delete_bucket_contents
         Empty the S3 bucket before stack deletion. Required if the bucket is
         non-empty; otherwise CloudFormation will refuse to delete it.
@@ -168,32 +196,29 @@ def teardown(
         If stack deletion or bucket emptying fails.
     """
     config = load_config()
-    if config is None or not config.profiles:
+    if config is None:
         print("No AG-Cloud config found — nothing to tear down.")
         return
-    try:
-        profile = config.get_profile(profile_name)
-    except KeyError:
-        print(f"Profile {profile_name!r} not found. Available profiles: {sorted(config.profiles)}")
-        return
-    active = profile_name or config.active_profile
 
-    if profile.stack_name is None:
-        delete_profile(active)
-        print(f"Removed profile {active!r} (no stack to delete).")
+    if config.stack_name is None:
+        delete_config()
+        print("Removed config (no stack to delete).")
         return
 
-    session = _boto_session(aws_profile=profile.aws_profile, region=profile.region)
+    session, account = _verified_session(session or boto3.Session(region_name=config.region))
     if delete_bucket_contents:
-        _empty_bucket(session, profile.bucket)
+        _empty_bucket(session, config.bucket)
 
-    print(f"Deleting CloudFormation stack {profile.stack_name!r} (this typically takes ~1 minute)...")
+    print(
+        f"Deleting CloudFormation stack {config.stack_name!r} "
+        f"(account {account}, region {config.region}, ~1 minute)..."
+    )
     cfn = session.client("cloudformation")
-    cfn.delete_stack(StackName=profile.stack_name)
-    cfn.get_waiter("stack_delete_complete").wait(StackName=profile.stack_name)
+    cfn.delete_stack(StackName=config.stack_name)
+    cfn.get_waiter("stack_delete_complete").wait(StackName=config.stack_name)
 
-    delete_profile(active)
-    print(f"Stack {profile.stack_name!r} deleted; removed profile {active!r}.")
+    delete_config()
+    print(f"Stack {config.stack_name!r} deleted; config removed.")
 
 
 # ---------------------------------------------------------------------------
@@ -201,29 +226,24 @@ def teardown(
 # ---------------------------------------------------------------------------
 
 
-def _boto_session(aws_profile: Optional[str] = None, region: Optional[str] = None) -> boto3.Session:
-    kwargs: Dict[str, Any] = {}
-    if aws_profile:
-        kwargs["profile_name"] = aws_profile
-    if region:
-        kwargs["region_name"] = region
-    return boto3.Session(**kwargs)
+def _verified_session(session: Optional[boto3.Session]) -> tuple[boto3.Session, str]:
+    """Build a default session if none given and verify it can call STS.
 
-
-def _verified_session(aws_profile: Optional[str] = None, region: Optional[str] = None) -> boto3.Session:
-    """Build a session and verify it can call sts:GetCallerIdentity."""
-    session = _boto_session(aws_profile=aws_profile, region=region)
+    Returns the session paired with the AWS account ID, so callers can show
+    the user what's about to happen (and where) without a second STS call.
+    """
+    session = session or boto3.Session()
     try:
-        session.client("sts").get_caller_identity()
+        identity = session.client("sts").get_caller_identity()
     except (NoCredentialsError, ClientError, BotoCoreError) as e:
         raise RuntimeError(
             "Could not detect AWS credentials. Run `aws configure`, set AWS_* "
-            "env vars, use AWS SSO, or pass `aws_profile=<name>`."
+            "env vars, use AWS SSO, or pass a configured `boto3.Session`."
         ) from e
-    return session
+    return session, identity["Account"]
 
 
-def _provision_stack(session: boto3.Session, *, stack_name: str, backend: Backend) -> tuple[str, str]:
+def _provision_stack(session: boto3.Session, *, stack_name: str, backend: BackendName) -> tuple[str, str]:
     """Deploy the bundled CFN template and return ``(role_arn, bucket_name)``."""
     cfn = session.client("cloudformation")
     template = resources.files("autogluon.cloud.templates").joinpath(f"ag_cloud_{backend}.yaml")
@@ -267,8 +287,8 @@ def _check_stack(session: boto3.Session, stack_name: str) -> str:
 
 
 def _check_role(session: boto3.Session, role_arn: str) -> str:
-    """Verify the IAM role exists. Does not assume it — that would bypass the
-    caller's boto3 identity.
+    """Verify the IAM role exists via iam:GetRole. Doesn't call sts:AssumeRole —
+    we only check existence, not the caller's permission to assume it.
     """
     try:
         session.client("iam").get_role(RoleName=role_arn.rsplit("/", 1)[-1])
@@ -280,5 +300,8 @@ def _check_role(session: boto3.Session, role_arn: str) -> str:
 def _empty_bucket(session: boto3.Session, bucket: str) -> None:
     print(f"Emptying bucket {bucket!r}...")
     b = session.resource("s3").Bucket(bucket)
+    # Both calls are needed for versioned buckets (our CFN template enables
+    # versioning): object_versions covers all historical versions + delete
+    # markers; objects covers anything left in the current listing.
     b.object_versions.delete()
     b.objects.delete()

--- a/src/autogluon/cloud/cloud_setup.py
+++ b/src/autogluon/cloud/cloud_setup.py
@@ -1,0 +1,284 @@
+"""Python API for provisioning AutoGluon-Cloud on AWS.
+
+Usage::
+
+    import autogluon.cloud as agc
+
+    agc.initialize(backend="sagemaker", region="us-east-1")   # deploy CFN + save config
+    agc.initialize(role_arn=..., bucket=...)                  # save config, skip CFN
+    agc.status()                                             # dict of health checks
+    agc.teardown(delete_bucket_contents=True)                # delete CFN + config
+"""
+
+from __future__ import annotations
+
+import typing
+from importlib import resources
+from typing import Any, Dict, Literal, Optional
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
+
+from .config import (
+    Profile,
+    delete_profile,
+    get_config_path,
+    load_config,
+    upsert_profile,
+)
+
+__all__ = ["initialize", "status", "teardown"]
+
+Backend = Literal["sagemaker", "ray_aws"]
+_SUPPORTED_BACKENDS = typing.get_args(Backend)
+
+
+def initialize(
+    *,
+    backend: Backend = "sagemaker",
+    region: Optional[str] = None,
+    stack_name: Optional[str] = None,
+    role_arn: Optional[str] = None,
+    bucket: Optional[str] = None,
+    aws_profile: Optional[str] = None,
+    profile_name: str = "default",
+) -> None:
+    """Provision AG-Cloud resources and save a config profile.
+
+    Either deploy a CloudFormation stack (creates an IAM role + S3 bucket
+    from scratch) or persist pre-existing resources — pass ``role_arn`` and
+    ``bucket`` together to skip CloudFormation. The persisted profile is the
+    canonical record; call :func:`status` to inspect it.
+
+    Parameters
+    ----------
+    backend
+        Which AG-Cloud backend to provision.
+    region
+        AWS region. Falls back to the boto3-configured region, then ``us-east-1``.
+    stack_name
+        CloudFormation stack name. Auto-generated as ``ag-cloud-<backend>``
+        if not given.
+    role_arn, bucket
+        If BOTH are given, skip CloudFormation and record these pre-existing
+        resources.
+    aws_profile
+        Local AWS profile name (from ``~/.aws/credentials`` or SSO) to use as
+        the base identity. Defaults to the standard boto3 credential chain.
+    profile_name
+        Name of the AG-Cloud profile entry in ``~/.autogluon/cloud.yaml``.
+
+    Raises
+    ------
+    ValueError
+        If ``role_arn`` and ``bucket`` aren't both provided together, or if
+        an unknown backend is passed.
+    RuntimeError
+        If AWS credentials can't be detected.
+    """
+    if (role_arn is None) ^ (bucket is None):
+        raise ValueError("`role_arn` and `bucket` must be provided together.")
+    if backend not in _SUPPORTED_BACKENDS:
+        raise ValueError(f"Unsupported backend {backend!r}. Choose from {_SUPPORTED_BACKENDS}.")
+
+    session = _verified_session(aws_profile=aws_profile, region=region)
+    region = session.region_name or "us-east-1"
+
+    if role_arn is None:
+        stack_name = stack_name or f"ag-cloud-{backend.replace('_', '-')}"
+        print(f"Deploying CloudFormation stack {stack_name!r} (this typically takes ~1 minute)...")
+        role_arn, bucket = _provision_stack(session, stack_name=stack_name, backend=backend)
+        print(f"Stack {stack_name!r} deployed.")
+
+    profile = Profile(
+        region=region,
+        role_arn=role_arn,
+        bucket=bucket,
+        backend=backend,
+        stack_name=stack_name,
+        aws_profile=aws_profile,
+    )
+    upsert_profile(profile_name, profile)
+    print(f"Saved profile {profile_name!r} to {get_config_path()}")
+
+
+def status(profile_name: Optional[str] = None, *, check_role: bool = True) -> Dict[str, Any]:
+    """Return a health snapshot of the named (or active) profile.
+
+    On found=True the dict contains ``profile`` (Profile), ``is_active`` (bool),
+    ``config_path`` (str), and ``checks`` (dict of ``bucket`` / ``stack`` /
+    ``role`` strings, each ``"ok"`` or a failure description).
+
+    On found=False the dict contains ``config_path`` and (if a profile name
+    was given but missing) ``reason`` and ``available_profiles``.
+
+    Makes real AWS calls. Pass ``check_role=False`` to skip ``iam:GetRole``.
+    """
+    config = load_config()
+    if config is None or not config.profiles:
+        return {"found": False, "config_path": str(get_config_path())}
+
+    try:
+        profile = config.get_profile(profile_name)
+    except KeyError:
+        return {
+            "found": False,
+            "config_path": str(get_config_path()),
+            "reason": "profile not found",
+            "requested_profile": profile_name,
+            "available_profiles": sorted(config.profiles),
+        }
+    active = profile_name or config.active_profile
+
+    session = _boto_session(aws_profile=profile.aws_profile, region=profile.region)
+    checks: Dict[str, str] = {"bucket": _check_bucket(session, profile.bucket)}
+    if profile.stack_name:
+        checks["stack"] = _check_stack(session, profile.stack_name)
+    if check_role:
+        checks["role"] = _check_role(session, profile.role_arn)
+
+    return {
+        "found": True,
+        "config_path": str(get_config_path()),
+        "profile_name": active,
+        "is_active": active == config.active_profile,
+        "profile": profile,
+        "checks": checks,
+    }
+
+
+def teardown(
+    profile_name: Optional[str] = None,
+    *,
+    delete_bucket_contents: bool = False,
+) -> None:
+    """Delete the CloudFormation stack and remove the profile from config.
+
+    Parameters
+    ----------
+    profile_name
+        Profile to tear down. Defaults to the active profile.
+    delete_bucket_contents
+        Empty the S3 bucket before stack deletion. Required if the bucket is
+        non-empty; otherwise CloudFormation will refuse to delete it.
+
+    Raises
+    ------
+    botocore.exceptions.ClientError, botocore.exceptions.WaiterError
+        If stack deletion or bucket emptying fails.
+    """
+    config = load_config()
+    if config is None or not config.profiles:
+        print("No AG-Cloud config found — nothing to tear down.")
+        return
+    try:
+        profile = config.get_profile(profile_name)
+    except KeyError:
+        print(f"Profile {profile_name!r} not found. Available profiles: {sorted(config.profiles)}")
+        return
+    active = profile_name or config.active_profile
+
+    if profile.stack_name is None:
+        delete_profile(active)
+        print(f"Removed profile {active!r} (no stack to delete).")
+        return
+
+    session = _boto_session(aws_profile=profile.aws_profile, region=profile.region)
+    if delete_bucket_contents:
+        _empty_bucket(session, profile.bucket)
+
+    print(f"Deleting CloudFormation stack {profile.stack_name!r} (this typically takes ~1 minute)...")
+    cfn = session.client("cloudformation")
+    cfn.delete_stack(StackName=profile.stack_name)
+    cfn.get_waiter("stack_delete_complete").wait(StackName=profile.stack_name)
+
+    delete_profile(active)
+    print(f"Stack {profile.stack_name!r} deleted; removed profile {active!r}.")
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _boto_session(aws_profile: Optional[str] = None, region: Optional[str] = None) -> boto3.Session:
+    kwargs: Dict[str, Any] = {}
+    if aws_profile:
+        kwargs["profile_name"] = aws_profile
+    if region:
+        kwargs["region_name"] = region
+    return boto3.Session(**kwargs)
+
+
+def _verified_session(aws_profile: Optional[str] = None, region: Optional[str] = None) -> boto3.Session:
+    """Build a session and verify it can call sts:GetCallerIdentity."""
+    session = _boto_session(aws_profile=aws_profile, region=region)
+    try:
+        session.client("sts").get_caller_identity()
+    except (NoCredentialsError, ClientError, BotoCoreError) as e:
+        raise RuntimeError(
+            "Could not detect AWS credentials. Run `aws configure`, set AWS_* "
+            "env vars, use AWS SSO, or pass `aws_profile=<name>`."
+        ) from e
+    return session
+
+
+def _provision_stack(session: boto3.Session, *, stack_name: str, backend: Backend) -> tuple[str, str]:
+    """Deploy the bundled CFN template and return ``(role_arn, bucket_name)``."""
+    cfn = session.client("cloudformation")
+    template = resources.files("autogluon.cloud.templates").joinpath(f"ag_cloud_{backend}.yaml")
+
+    try:
+        cfn.create_stack(
+            StackName=stack_name,
+            TemplateBody=template.read_text(),
+            Capabilities=["CAPABILITY_NAMED_IAM"],
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] != "AlreadyExistsException":
+            raise
+        print(f"Stack {stack_name!r} already exists — reusing it.")
+
+    cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
+
+    outputs = {
+        o["OutputKey"]: o["OutputValue"]
+        for o in cfn.describe_stacks(StackName=stack_name)["Stacks"][0].get("Outputs", [])
+    }
+    missing = {"RoleARN", "BucketName"} - outputs.keys()
+    if missing:
+        raise RuntimeError(f"Stack outputs missing required keys: {missing}")
+    return outputs["RoleARN"], outputs["BucketName"]
+
+
+def _check_bucket(session: boto3.Session, bucket: str) -> str:
+    try:
+        session.client("s3").head_bucket(Bucket=bucket)
+        return "ok"
+    except ClientError as e:
+        return f"failed ({e.response.get('Error', {}).get('Code', '?')})"
+
+
+def _check_stack(session: boto3.Session, stack_name: str) -> str:
+    try:
+        return session.client("cloudformation").describe_stacks(StackName=stack_name)["Stacks"][0]["StackStatus"]
+    except ClientError as e:
+        return e.response["Error"]["Message"]
+
+
+def _check_role(session: boto3.Session, role_arn: str) -> str:
+    """Verify the IAM role exists. Does not assume it — that would bypass the
+    caller's boto3 identity.
+    """
+    try:
+        session.client("iam").get_role(RoleName=role_arn.rsplit("/", 1)[-1])
+        return "ok"
+    except ClientError as e:
+        return f"failed ({e.response.get('Error', {}).get('Code', '?')})"
+
+
+def _empty_bucket(session: boto3.Session, bucket: str) -> None:
+    print(f"Emptying bucket {bucket!r}...")
+    b = session.resource("s3").Bucket(bucket)
+    b.object_versions.delete()
+    b.objects.delete()

--- a/src/autogluon/cloud/cloud_setup.py
+++ b/src/autogluon/cloud/cloud_setup.py
@@ -5,21 +5,23 @@ Usage::
     from autogluon.cloud import bootstrap, register, status, teardown
 
     bootstrap()                                          # deploy CFN + save config
-    register(role_arn=..., bucket=..., region=...)       # save existing resources
-    status()                                             # dict of health checks
-    teardown(delete_bucket_contents=True)                # delete CFN + config
+    register(backend=, role=, bucket=, region=)          # save existing resources
+    status()                                             # dict of StatusReport per backend
+    teardown()                                           # delete CFN + config (all backends)
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from importlib import resources
-from typing import Any, Dict, Literal, Optional
+from typing import Dict, Literal, Optional
 
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
 
-from .backend.constant import RAY_AWS, SAGEMAKER, SUPPORTED_SETUP_BACKENDS
+from .backend.constant import SUPPORTED_SETUP_BACKENDS
 from .config import (
+    BackendConfig,
     CloudConfig,
     delete_config,
     get_config_path,
@@ -27,9 +29,20 @@ from .config import (
     save_config,
 )
 
-__all__ = ["bootstrap", "register", "status", "teardown"]
+__all__ = ["bootstrap", "register", "status", "teardown", "StatusReport"]
 
-BackendName = Literal[SAGEMAKER, RAY_AWS]
+
+@dataclass
+class StatusReport:
+    """Health snapshot for a single backend."""
+
+    config: BackendConfig
+    config_path: str
+    checks: Dict[str, str] = field(default_factory=dict)
+
+
+# Keep these values in sync with SUPPORTED_SETUP_BACKENDS in backend/constant.py.
+BackendName = Literal["sagemaker", "ray_aws"]
 
 
 def bootstrap(
@@ -40,29 +53,22 @@ def bootstrap(
 ) -> None:
     """Deploy the CloudFormation stack and persist resource identifiers.
 
-    On completion the IAM role and S3 bucket created by the stack are saved
-    to ``~/.autogluon/cloud.yaml`` via :func:`register`. If you
-    already have an IAM role and bucket in place, call :func:`register`
-    directly and skip this function entirely.
+    On completion the IAM role and S3 bucket created by the stack are saved to ``~/.autogluon/cloud.yaml`` via
+    :func:`register`. If you already have an IAM role and bucket in place, call :func:`register` directly and
+    skip this function entirely.
+
+    Each backend has its own slot in the config file, so calling :func:`bootstrap` for ``sagemaker`` and again
+    for ``ray_aws`` keeps both in the config.
 
     Parameters
     ----------
     backend
         Which AG-Cloud backend to provision.
     stack_name
-        CloudFormation stack name. Auto-generated as ``ag-cloud-<backend>``
-        if not given.
+        CloudFormation stack name. Auto-generated as ``ag-cloud-<backend>`` if not given.
     session
-        A ``boto3.Session`` to use for AWS calls. If ``None``, a default
-        session is constructed from the standard credential chain
-        (env vars, ``~/.aws/credentials``, SSO, instance profile).
-
-    Raises
-    ------
-    ValueError
-        If an unknown backend is passed.
-    RuntimeError
-        If AWS credentials can't be detected.
+        A ``boto3.Session`` to use for AWS calls. If ``None``, a default session is constructed from the standard
+        credential chain (env vars, ``~/.aws/credentials``, SSO, instance profile).
     """
     if backend not in SUPPORTED_SETUP_BACKENDS:
         raise ValueError(f"Unsupported backend {backend!r}. Choose from {SUPPORTED_SETUP_BACKENDS}.")
@@ -81,7 +87,7 @@ def bootstrap(
     print(f"Stack {stack_name!r} deployed.")
 
     register(
-        role_arn=role_arn,
+        role=role_arn,
         bucket=bucket,
         region=region,
         backend=backend,
@@ -91,134 +97,142 @@ def bootstrap(
 
 def register(
     *,
-    role_arn: str,
+    role: str,
     bucket: str,
     region: str,
     backend: BackendName = "sagemaker",
     stack_name: Optional[str] = None,
 ) -> None:
-    """Persist resource identifiers to ``~/.autogluon/cloud.yaml``.
+    """Persist resource identifiers to ``~/.autogluon/cloud.yaml`` under the given backend key.
 
-    Use this when you already have an IAM role and S3 bucket — for example,
-    centrally provisioned by your platform team — and just want AG-Cloud to
-    remember them. Pure file I/O; no AWS calls.
+    Use this when you already have an IAM role and S3 bucket — for example, centrally provisioned by your platform
+    team — and just want AG-Cloud to remember them.
+
+    If a config entry already exists for ``backend``, it is overwritten. Other backends in the file are left
+    untouched.
 
     Parameters
     ----------
-    role_arn
-        ARN of an IAM role suitable for SageMaker / Ray to assume.
+    role
+        ARN of an IAM role suitable for SageMaker / Ray to assume. Named ``role`` for consistency with the SageMaker
+        Python SDK (which uses ``role`` as the parameter name).
     bucket
         S3 bucket name where AG-Cloud will read/write artifacts.
     region
         AWS region for AG-Cloud operations.
     backend
-        Which AG-Cloud backend the resources are intended for.
+        Which AG-Cloud backend the resources are intended for. Selects the slot in ``cloud.yaml``.
     stack_name
-        Optional CloudFormation stack name. If you deployed the resources
-        via your own CFN stack and want :func:`teardown` to be able to
-        delete it later, pass the name here. Defaults to ``None``, meaning
-        teardown will only remove the config file, not touch AWS.
-
-    Raises
-    ------
-    ValueError
-        If an unknown backend is passed.
+        Optional CloudFormation stack name. If you deployed the resources via your own CFN stack and want
+        :func:`teardown` to be able to delete it later, pass the name here. Defaults to ``None``, meaning teardown
+        will only remove the config entry, not touch AWS.
     """
     if backend not in SUPPORTED_SETUP_BACKENDS:
         raise ValueError(f"Unsupported backend {backend!r}. Choose from {SUPPORTED_SETUP_BACKENDS}.")
-    config = CloudConfig(
+    config = load_config() or CloudConfig()
+    config.backends[backend] = BackendConfig(
         region=region,
-        role_arn=role_arn,
+        role_arn=role,
         bucket=bucket,
-        backend=backend,
         stack_name=stack_name,
     )
     save_config(config)
-    print(f"Saved AG-Cloud config to {get_config_path()}")
+    print(f"Saved AG-Cloud config for backend {backend!r} to {get_config_path()}")
 
 
 def status(
     *,
     session: Optional[boto3.Session] = None,
-    check_role: bool = True,
-) -> Dict[str, Any]:
-    """Return a health snapshot of the persisted config.
+) -> Dict[str, StatusReport]:
+    """Return health snapshots keyed by backend name, one per configured backend.
 
-    On found=True the dict contains ``config`` (CloudConfig), ``config_path``
-    (str), and ``checks`` (dict of ``bucket`` / ``stack`` / ``role`` strings,
-    each ``"ok"`` or a failure description).
+    Each :class:`StatusReport` has:
 
-    On found=False the dict contains just ``config_path``.
+    * ``config`` — the saved :class:`BackendConfig`
+    * ``config_path`` — path to ``~/.autogluon/cloud.yaml``
+    * ``checks`` — dict of ``bucket`` / ``stack`` / ``role`` to a status string. ``"ok"`` means the resource exists;
+      ``"ok (unverified)"`` means the caller lacks the IAM permission to verify and the resource may still be fine;
+      anything else is a failure description.
 
-    Makes real AWS calls. Pass ``check_role=False`` to skip ``iam:GetRole``.
-    Pass ``session=`` to use specific credentials; otherwise the standard
-    boto3 credential chain is used (with the saved region as a default).
+    Returns an empty dict if no config exists. Makes real AWS calls. Pass ``session=`` to use specific credentials;
+    otherwise the standard boto3 credential chain is used (with the saved region as a default).
     """
     config = load_config()
     if config is None:
-        return {"found": False, "config_path": str(get_config_path())}
+        return {}
 
-    session = session or boto3.Session(region_name=config.region)
-    checks: Dict[str, str] = {"bucket": _check_bucket(session, config.bucket)}
-    if config.stack_name:
-        checks["stack"] = _check_stack(session, config.stack_name)
-    if check_role:
-        checks["role"] = _check_role(session, config.role_arn)
-
-    return {
-        "found": True,
-        "config_path": str(get_config_path()),
-        "config": config,
-        "checks": checks,
-    }
+    reports: Dict[str, StatusReport] = {}
+    for name in list(config.backends):
+        backend_config = config.backends.get(name)
+        if backend_config is None:
+            continue
+        sess = session or boto3.Session(region_name=backend_config.region)
+        checks: Dict[str, str] = {"bucket": _check_bucket(sess, backend_config.bucket)}
+        if backend_config.stack_name:
+            checks["stack"] = _check_stack(sess, backend_config.stack_name)
+        checks["role"] = _check_role(sess, backend_config.role_arn)
+        reports[name] = StatusReport(
+            config=backend_config,
+            config_path=str(get_config_path()),
+            checks=checks,
+        )
+    return reports
 
 
 def teardown(
     *,
+    backend: Optional[BackendName] = None,
     session: Optional[boto3.Session] = None,
-    delete_bucket_contents: bool = False,
 ) -> None:
-    """Delete the CloudFormation stack (if any) and remove the config file.
+    """Delete a backend's CloudFormation stack and remove its config entry.
+
+    With ``backend=None`` (default), tears down every configured backend and removes the config file. With
+    ``backend="sagemaker"``, tears down just that one and leaves any other backends in the config.
+
+    The S3 buckets are **not** emptied for you: CloudFormation refuses to delete a non-empty bucket, so you must
+    remove their contents (e.g. via ``aws s3 rm s3://<bucket> --recursive``) before calling :func:`teardown`. This
+    is intentional — buckets may contain training artifacts or model weights that are expensive to recreate.
 
     Parameters
     ----------
+    backend
+        Which backend to tear down. ``None`` (default) tears down all configured backends.
     session
-        A ``boto3.Session`` to use for AWS calls. If ``None``, a default
-        session is built from the standard credential chain, with the saved
-        region applied automatically.
-    delete_bucket_contents
-        Empty the S3 bucket before stack deletion. Required if the bucket is
-        non-empty; otherwise CloudFormation will refuse to delete it.
-
-    Raises
-    ------
-    botocore.exceptions.ClientError, botocore.exceptions.WaiterError
-        If stack deletion or bucket emptying fails.
+        A ``boto3.Session`` to use for AWS calls. If ``None``, a default session is built from the standard
+        credential chain, with each backend's saved region applied automatically.
     """
     config = load_config()
-    if config is None:
+    if config is None or not config.backends:
         print("No AG-Cloud config found — nothing to tear down.")
         return
 
-    if config.stack_name is None:
-        delete_config()
-        print("Removed config (no stack to delete).")
+    if backend is not None and backend not in config.backends:
+        print(f"Backend {backend!r} not in config. Available: {sorted(config.backends)}")
         return
 
-    session, account = _verified_session(session or boto3.Session(region_name=config.region))
-    if delete_bucket_contents:
-        _empty_bucket(session, config.bucket)
+    targets = [backend] if backend is not None else list(config.backends)
+    for name in targets:
+        backend_config = config.backends[name]
+        if backend_config.stack_name is None:
+            print(f"[{name}] no stack to delete.")
+        else:
+            sess, account = _verified_session(session or boto3.Session(region_name=backend_config.region))
+            print(
+                f"[{name}] Deleting CloudFormation stack {backend_config.stack_name!r} "
+                f"(account {account}, region {backend_config.region}, ~1 minute)..."
+            )
+            cfn = sess.client("cloudformation")
+            cfn.delete_stack(StackName=backend_config.stack_name)
+            cfn.get_waiter("stack_delete_complete").wait(StackName=backend_config.stack_name)
+            print(f"[{name}] Stack {backend_config.stack_name!r} deleted.")
+        del config.backends[name]
 
-    print(
-        f"Deleting CloudFormation stack {config.stack_name!r} "
-        f"(account {account}, region {config.region}, ~1 minute)..."
-    )
-    cfn = session.client("cloudformation")
-    cfn.delete_stack(StackName=config.stack_name)
-    cfn.get_waiter("stack_delete_complete").wait(StackName=config.stack_name)
-
-    delete_config()
-    print(f"Stack {config.stack_name!r} deleted; config removed.")
+    if config.backends:
+        save_config(config)
+        print(f"Removed {targets} from config; remaining backends: {sorted(config.backends)}.")
+    else:
+        delete_config()
+        print("Removed config file.")
 
 
 # ---------------------------------------------------------------------------
@@ -248,6 +262,7 @@ def _provision_stack(session: boto3.Session, *, stack_name: str, backend: Backen
     cfn = session.client("cloudformation")
     template = resources.files("autogluon.cloud.templates").joinpath(f"ag_cloud_{backend}.yaml")
 
+    stack_existed = False
     try:
         cfn.create_stack(
             StackName=stack_name,
@@ -257,18 +272,32 @@ def _provision_stack(session: boto3.Session, *, stack_name: str, backend: Backen
     except ClientError as e:
         if e.response["Error"]["Code"] != "AlreadyExistsException":
             raise
+        stack_existed = True
         print(f"Stack {stack_name!r} already exists — reusing it.")
 
-    cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
+    if not stack_existed:
+        cfn.get_waiter("stack_create_complete").wait(StackName=stack_name)
 
-    outputs = {
-        o["OutputKey"]: o["OutputValue"]
-        for o in cfn.describe_stacks(StackName=stack_name)["Stacks"][0].get("Outputs", [])
-    }
+    desc = cfn.describe_stacks(StackName=stack_name)["Stacks"][0]
+    outputs = {o["OutputKey"]: o["OutputValue"] for o in desc.get("Outputs", [])}
     missing = {"RoleARN", "BucketName"} - outputs.keys()
     if missing:
-        raise RuntimeError(f"Stack outputs missing required keys: {missing}")
+        raise RuntimeError(
+            f"Stack {stack_name!r} is in {desc['StackStatus']} and missing required outputs: {missing}. "
+            f"Delete it via the CloudFormation console and re-run."
+        )
     return outputs["RoleARN"], outputs["BucketName"]
+
+
+# AWS error codes that mean "the caller lacks IAM permission to read this", as
+# distinct from "the resource doesn't exist". We surface these as ``"unverified"``
+# rather than ``"failed"`` so users don't think their setup is broken when really
+# it's just a permissions gap on the side of whoever is running ``status()``.
+_PERMISSION_ERROR_CODES = frozenset({"AccessDenied", "AccessDeniedException", "Forbidden", "UnauthorizedOperation"})
+
+
+def _is_permission_error(e: ClientError) -> bool:
+    return e.response.get("Error", {}).get("Code", "") in _PERMISSION_ERROR_CODES
 
 
 def _check_bucket(session: boto3.Session, bucket: str) -> str:
@@ -276,6 +305,8 @@ def _check_bucket(session: boto3.Session, bucket: str) -> str:
         session.client("s3").head_bucket(Bucket=bucket)
         return "ok"
     except ClientError as e:
+        if _is_permission_error(e):
+            return "ok (unverified — caller lacks s3:HeadBucket)"
         return f"failed ({e.response.get('Error', {}).get('Code', '?')})"
 
 
@@ -283,6 +314,8 @@ def _check_stack(session: boto3.Session, stack_name: str) -> str:
     try:
         return session.client("cloudformation").describe_stacks(StackName=stack_name)["Stacks"][0]["StackStatus"]
     except ClientError as e:
+        if _is_permission_error(e):
+            return "ok (unverified — caller lacks cloudformation:DescribeStacks)"
         return e.response["Error"]["Message"]
 
 
@@ -290,18 +323,13 @@ def _check_role(session: boto3.Session, role_arn: str) -> str:
     """Verify the IAM role exists via iam:GetRole. Doesn't call sts:AssumeRole —
     we only check existence, not the caller's permission to assume it.
     """
+    # iam:GetRole's RoleName takes the bare name, not the path. For a role with a path
+    # (e.g. arn:aws:iam::123:role/prod/MyRole), the name is the segment after final '/'
+    role_name = role_arn.rsplit("/", 1)[-1]
     try:
-        session.client("iam").get_role(RoleName=role_arn.rsplit("/", 1)[-1])
+        session.client("iam").get_role(RoleName=role_name)
         return "ok"
     except ClientError as e:
+        if _is_permission_error(e):
+            return "ok (unverified — caller lacks iam:GetRole)"
         return f"failed ({e.response.get('Error', {}).get('Code', '?')})"
-
-
-def _empty_bucket(session: boto3.Session, bucket: str) -> None:
-    print(f"Emptying bucket {bucket!r}...")
-    b = session.resource("s3").Bucket(bucket)
-    # Both calls are needed for versioned buckets (our CFN template enables
-    # versioning): object_versions covers all historical versions + delete
-    # markers; objects covers anything left in the current listing.
-    b.object_versions.delete()
-    b.objects.delete()

--- a/src/autogluon/cloud/cloud_setup.py
+++ b/src/autogluon/cloud/cloud_setup.py
@@ -19,7 +19,7 @@ from typing import Dict, Literal, Optional
 import boto3
 from botocore.exceptions import BotoCoreError, ClientError, NoCredentialsError
 
-from .backend.constant import SUPPORTED_SETUP_BACKENDS
+from .backend.constant import SUPPORTED_BACKENDS
 from .config import (
     BackendConfig,
     CloudConfig,
@@ -41,7 +41,7 @@ class StatusReport:
     checks: Dict[str, str] = field(default_factory=dict)
 
 
-# Keep these values in sync with SUPPORTED_SETUP_BACKENDS in backend/constant.py.
+# Keep these values in sync with SUPPORTED_BACKENDS in backend/constant.py.
 BackendName = Literal["sagemaker", "ray_aws"]
 
 
@@ -70,8 +70,8 @@ def bootstrap(
         A ``boto3.Session`` to use for AWS calls. If ``None``, a default session is constructed from the standard
         credential chain (env vars, ``~/.aws/credentials``, SSO, instance profile).
     """
-    if backend not in SUPPORTED_SETUP_BACKENDS:
-        raise ValueError(f"Unsupported backend {backend!r}. Choose from {SUPPORTED_SETUP_BACKENDS}.")
+    if backend not in SUPPORTED_BACKENDS:
+        raise ValueError(f"Unsupported backend {backend!r}. Choose from {SUPPORTED_BACKENDS}.")
 
     session, account = _verified_session(session)
     region = session.region_name
@@ -127,8 +127,8 @@ def register(
         :func:`teardown` to be able to delete it later, pass the name here. Defaults to ``None``, meaning teardown
         will only remove the config entry, not touch AWS.
     """
-    if backend not in SUPPORTED_SETUP_BACKENDS:
-        raise ValueError(f"Unsupported backend {backend!r}. Choose from {SUPPORTED_SETUP_BACKENDS}.")
+    if backend not in SUPPORTED_BACKENDS:
+        raise ValueError(f"Unsupported backend {backend!r}. Choose from {SUPPORTED_BACKENDS}.")
     config = load_config() or CloudConfig()
     config.backends[backend] = BackendConfig(
         region=region,
@@ -162,10 +162,7 @@ def status(
         return {}
 
     reports: Dict[str, StatusReport] = {}
-    for name in list(config.backends):
-        backend_config = config.backends.get(name)
-        if backend_config is None:
-            continue
+    for name, backend_config in config.backends.items():
         sess = session or boto3.Session(region_name=backend_config.region)
         checks: Dict[str, str] = {"bucket": _check_bucket(sess, backend_config.bucket)}
         if backend_config.stack_name:
@@ -289,15 +286,17 @@ def _provision_stack(session: boto3.Session, *, stack_name: str, backend: Backen
     return outputs["RoleARN"], outputs["BucketName"]
 
 
-# AWS error codes that mean "the caller lacks IAM permission to read this", as
-# distinct from "the resource doesn't exist". We surface these as ``"unverified"``
-# rather than ``"failed"`` so users don't think their setup is broken when really
-# it's just a permissions gap on the side of whoever is running ``status()``.
-_PERMISSION_ERROR_CODES = frozenset({"AccessDenied", "AccessDeniedException", "Forbidden", "UnauthorizedOperation"})
-
-
 def _is_permission_error(e: ClientError) -> bool:
-    return e.response.get("Error", {}).get("Code", "") in _PERMISSION_ERROR_CODES
+    # AWS error codes that mean "the caller lacks IAM permission to read this", as
+    # distinct from "the resource doesn't exist". We surface these as ``"unverified"``
+    # rather than ``"failed"`` so users don't think their setup is broken when really
+    # it's just a permissions gap on the side of whoever is running ``status()``.
+    return e.response.get("Error", {}).get("Code", "") in {
+        "AccessDenied",
+        "AccessDeniedException",
+        "Forbidden",
+        "UnauthorizedOperation",
+    }
 
 
 def _check_bucket(session: boto3.Session, bucket: str) -> str:

--- a/src/autogluon/cloud/config.py
+++ b/src/autogluon/cloud/config.py
@@ -1,0 +1,117 @@
+"""Persistent config for AutoGluon-Cloud.
+
+Stores per-profile information (region, stack name, bucket, IAM role ARN) at
+``~/.autogluon/cloud.yaml`` so users don't need to re-specify these every
+session. The file contains only non-secret identifiers — no AWS credentials
+are ever written to disk.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Dict, Optional
+
+import yaml
+
+logger = logging.getLogger(__name__)
+
+CONFIG_VERSION = 1
+DEFAULT_PROFILE = "default"
+CONFIG_DIR_ENV = "AUTOGLUON_CLOUD_CONFIG_DIR"
+PROFILE_ENV = "AUTOGLUON_CLOUD_PROFILE"
+
+
+def get_config_dir() -> Path:
+    override = os.environ.get(CONFIG_DIR_ENV)
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".autogluon"
+
+
+def get_config_path() -> Path:
+    return get_config_dir() / "cloud.yaml"
+
+
+@dataclass
+class Profile:
+    region: str
+    role_arn: str
+    bucket: str
+    backend: str = "sagemaker"
+    stack_name: Optional[str] = None
+    aws_profile: Optional[str] = None
+
+
+@dataclass
+class CloudConfig:
+    version: int = CONFIG_VERSION
+    active_profile: str = DEFAULT_PROFILE
+    profiles: Dict[str, Profile] = field(default_factory=dict)
+
+    def get_profile(self, name: Optional[str] = None) -> Profile:
+        name = name or os.environ.get(PROFILE_ENV) or self.active_profile
+        if name not in self.profiles:
+            raise KeyError(
+                f"Profile {name!r} not found in {get_config_path()}. Available profiles: {sorted(self.profiles)}"
+            )
+        return self.profiles[name]
+
+
+def load_config() -> Optional[CloudConfig]:
+    """Load the config file, or return None if it doesn't exist.
+
+    Returns None (rather than raising) so callers can gracefully fall back to
+    requiring explicit ``cloud_output_path`` and role ARN.
+    """
+    path = get_config_path()
+    if not path.exists():
+        return None
+    with path.open("r") as f:
+        raw = yaml.safe_load(f) or {}
+    profiles = {name: Profile(**data) for name, data in (raw.get("profiles") or {}).items()}
+    return CloudConfig(
+        version=raw.get("version", CONFIG_VERSION),
+        active_profile=raw.get("active_profile", DEFAULT_PROFILE),
+        profiles=profiles,
+    )
+
+
+def save_config(config: CloudConfig) -> Path:
+    """Persist config atomically with 0600 file perms."""
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": config.version,
+        "active_profile": config.active_profile,
+        "profiles": {name: asdict(p) for name, p in config.profiles.items()},
+    }
+    tmp = path.with_suffix(".yaml.tmp")
+    with tmp.open("w") as f:
+        yaml.safe_dump(payload, f, sort_keys=False)
+    os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
+    os.replace(tmp, path)
+    return path
+
+
+def upsert_profile(name: str, profile: Profile, set_active: bool = True) -> CloudConfig:
+    config = load_config() or CloudConfig()
+    config.profiles[name] = profile
+    if set_active or len(config.profiles) == 1:
+        config.active_profile = name
+    save_config(config)
+    return config
+
+
+def delete_profile(name: str) -> bool:
+    config = load_config()
+    if config is None or name not in config.profiles:
+        return False
+    del config.profiles[name]
+    if config.active_profile == name:
+        config.active_profile = next(iter(config.profiles), DEFAULT_PROFILE)
+    save_config(config)
+    return True

--- a/src/autogluon/cloud/config.py
+++ b/src/autogluon/cloud/config.py
@@ -30,7 +30,7 @@ from typing import Dict, Optional
 
 import yaml
 
-CONFIG_DIR_ENV = "AUTOGLUON_CLOUD_CONFIG_DIR"
+CONFIG_DIR_ENV = "AG_CONFIG_DIR"
 
 
 def get_config_dir() -> Path:

--- a/src/autogluon/cloud/config.py
+++ b/src/autogluon/cloud/config.py
@@ -8,7 +8,6 @@ are ever written to disk.
 
 from __future__ import annotations
 
-import logging
 import os
 import stat
 from dataclasses import asdict, dataclass, field
@@ -16,8 +15,6 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import yaml
-
-logger = logging.getLogger(__name__)
 
 CONFIG_VERSION = 1
 DEFAULT_PROFILE = "default"
@@ -72,7 +69,9 @@ def load_config() -> Optional[CloudConfig]:
         return None
     with path.open("r") as f:
         raw = yaml.safe_load(f) or {}
-    profiles = {name: Profile(**data) for name, data in (raw.get("profiles") or {}).items()}
+    profiles = {
+        name: Profile(**data) for name, data in (raw.get("profiles") or {}).items()
+    }
     return CloudConfig(
         version=raw.get("version", CONFIG_VERSION),
         active_profile=raw.get("active_profile", DEFAULT_PROFILE),

--- a/src/autogluon/cloud/config.py
+++ b/src/autogluon/cloud/config.py
@@ -4,15 +4,29 @@ Stores resource identifiers (region, stack name, bucket, IAM role ARN) at
 ``~/.autogluon/cloud.yaml`` so users don't need to re-specify them every
 session. The file contains only non-secret identifiers — no AWS credentials
 are ever written to disk.
+
+The file is keyed by backend name so a user can have entries for multiple backends like
+``sagemaker`` and ``ray_aws`` configured at the same time::
+
+    sagemaker:
+      region: us-east-1
+      role_arn: arn:aws:iam::...:role/ag-cloud-sagemaker-execution-role
+      bucket: ag-cloud-sagemaker-bucket-...
+      stack_name: ag-cloud-sagemaker
+    ray_aws:
+      region: us-east-1
+      role_arn: arn:aws:iam::...:role/ag-cloud-ray-aws-execution-role
+      bucket: ag-cloud-ray-aws-bucket-...
+      stack_name: ag-cloud-ray-aws
 """
 
 from __future__ import annotations
 
 import os
 import stat
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 import yaml
 
@@ -31,16 +45,24 @@ def get_config_path() -> Path:
 
 
 @dataclass
-class CloudConfig:
+class BackendConfig:
+    """Persisted identifiers for a single AG-Cloud backend."""
+
     region: str
     role_arn: str
     bucket: str
-    backend: str = "sagemaker"
     stack_name: Optional[str] = None
 
 
+@dataclass
+class CloudConfig:
+    """Top-level config: maps backend name → BackendConfig."""
+
+    backends: Dict[str, BackendConfig] = field(default_factory=dict)
+
+
 def load_config() -> Optional[CloudConfig]:
-    """Load the config file, or return None if it doesn't exist."""
+    """Load the config file, or return None if it doesn't exist or is empty."""
     path = get_config_path()
     if not path.exists():
         return None
@@ -48,16 +70,18 @@ def load_config() -> Optional[CloudConfig]:
         raw = yaml.safe_load(f) or {}
     if not raw:
         return None
-    return CloudConfig(**raw)
+    backends = {name: BackendConfig(**data) for name, data in raw.items()}
+    return CloudConfig(backends=backends)
 
 
 def save_config(config: CloudConfig) -> Path:
     """Persist config atomically with 0600 file perms."""
     path = get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {name: asdict(b) for name, b in config.backends.items()}
     tmp = path.with_suffix(".yaml.tmp")
     with tmp.open("w") as f:
-        yaml.safe_dump(asdict(config), f, sort_keys=False)
+        yaml.safe_dump(payload, f, sort_keys=False)
     os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
     os.replace(tmp, path)
     return path

--- a/src/autogluon/cloud/config.py
+++ b/src/autogluon/cloud/config.py
@@ -1,7 +1,7 @@
 """Persistent config for AutoGluon-Cloud.
 
-Stores per-profile information (region, stack name, bucket, IAM role ARN) at
-``~/.autogluon/cloud.yaml`` so users don't need to re-specify these every
+Stores resource identifiers (region, stack name, bucket, IAM role ARN) at
+``~/.autogluon/cloud.yaml`` so users don't need to re-specify them every
 session. The file contains only non-secret identifiers — no AWS credentials
 are ever written to disk.
 """
@@ -10,16 +10,13 @@ from __future__ import annotations
 
 import os
 import stat
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict, dataclass
 from pathlib import Path
-from typing import Dict, Optional
+from typing import Optional
 
 import yaml
 
-CONFIG_VERSION = 1
-DEFAULT_PROFILE = "default"
 CONFIG_DIR_ENV = "AUTOGLUON_CLOUD_CONFIG_DIR"
-PROFILE_ENV = "AUTOGLUON_CLOUD_PROFILE"
 
 
 def get_config_dir() -> Path:
@@ -34,81 +31,42 @@ def get_config_path() -> Path:
 
 
 @dataclass
-class Profile:
+class CloudConfig:
     region: str
     role_arn: str
     bucket: str
     backend: str = "sagemaker"
     stack_name: Optional[str] = None
-    aws_profile: Optional[str] = None
-
-
-@dataclass
-class CloudConfig:
-    version: int = CONFIG_VERSION
-    active_profile: str = DEFAULT_PROFILE
-    profiles: Dict[str, Profile] = field(default_factory=dict)
-
-    def get_profile(self, name: Optional[str] = None) -> Profile:
-        name = name or os.environ.get(PROFILE_ENV) or self.active_profile
-        if name not in self.profiles:
-            raise KeyError(
-                f"Profile {name!r} not found in {get_config_path()}. Available profiles: {sorted(self.profiles)}"
-            )
-        return self.profiles[name]
 
 
 def load_config() -> Optional[CloudConfig]:
-    """Load the config file, or return None if it doesn't exist.
-
-    Returns None (rather than raising) so callers can gracefully fall back to
-    requiring explicit ``cloud_output_path`` and role ARN.
-    """
+    """Load the config file, or return None if it doesn't exist."""
     path = get_config_path()
     if not path.exists():
         return None
     with path.open("r") as f:
         raw = yaml.safe_load(f) or {}
-    profiles = {name: Profile(**data) for name, data in (raw.get("profiles") or {}).items()}
-    return CloudConfig(
-        version=raw.get("version", CONFIG_VERSION),
-        active_profile=raw.get("active_profile", DEFAULT_PROFILE),
-        profiles=profiles,
-    )
+    if not raw:
+        return None
+    return CloudConfig(**raw)
 
 
 def save_config(config: CloudConfig) -> Path:
     """Persist config atomically with 0600 file perms."""
     path = get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "version": config.version,
-        "active_profile": config.active_profile,
-        "profiles": {name: asdict(p) for name, p in config.profiles.items()},
-    }
     tmp = path.with_suffix(".yaml.tmp")
     with tmp.open("w") as f:
-        yaml.safe_dump(payload, f, sort_keys=False)
+        yaml.safe_dump(asdict(config), f, sort_keys=False)
     os.chmod(tmp, stat.S_IRUSR | stat.S_IWUSR)
     os.replace(tmp, path)
     return path
 
 
-def upsert_profile(name: str, profile: Profile, set_active: bool = True) -> CloudConfig:
-    config = load_config() or CloudConfig()
-    config.profiles[name] = profile
-    if set_active or len(config.profiles) == 1:
-        config.active_profile = name
-    save_config(config)
-    return config
-
-
-def delete_profile(name: str) -> bool:
-    config = load_config()
-    if config is None or name not in config.profiles:
+def delete_config() -> bool:
+    """Remove the config file. Returns True if a file was deleted."""
+    path = get_config_path()
+    if not path.exists():
         return False
-    del config.profiles[name]
-    if config.active_profile == name:
-        config.active_profile = next(iter(config.profiles), DEFAULT_PROFILE)
-    save_config(config)
+    path.unlink()
     return True

--- a/src/autogluon/cloud/config.py
+++ b/src/autogluon/cloud/config.py
@@ -69,9 +69,7 @@ def load_config() -> Optional[CloudConfig]:
         return None
     with path.open("r") as f:
         raw = yaml.safe_load(f) or {}
-    profiles = {
-        name: Profile(**data) for name, data in (raw.get("profiles") or {}).items()
-    }
+    profiles = {name: Profile(**data) for name, data in (raw.get("profiles") or {}).items()}
     return CloudConfig(
         version=raw.get("version", CONFIG_VERSION),
         active_profile=raw.get("active_profile", DEFAULT_PROFILE),

--- a/tests/unittests/general/test_cloud_setup.py
+++ b/tests/unittests/general/test_cloud_setup.py
@@ -1,0 +1,189 @@
+"""Tests for the top-level Python API (autogluon.cloud.initialize/status/teardown)."""
+
+import pytest
+
+import autogluon.cloud as agc
+from autogluon.cloud.config import CONFIG_DIR_ENV, load_config, save_config
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    yield tmp_path
+
+
+@pytest.fixture(autouse=True)
+def stub_aws(monkeypatch):
+    """Stub out the credential-verification call so tests don't hit AWS."""
+
+    class _StubSession:
+        def __init__(self, region):
+            self.region_name = region or "us-east-1"
+
+    monkeypatch.setattr(
+        "autogluon.cloud.cloud_setup._verified_session",
+        lambda aws_profile=None, region=None: _StubSession(region),
+    )
+
+
+def _initialize_existing(**overrides):
+    kwargs = dict(
+        backend="sagemaker",
+        region="us-east-1",
+        role_arn="arn:aws:iam::111122223333:role/x",
+        bucket="b1",
+    )
+    kwargs.update(overrides)
+    agc.initialize(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# initialize
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_with_existing_resources_writes_config():
+    """`initialize(role_arn=..., bucket=...)` writes config without CloudFormation."""
+    _initialize_existing(region="us-west-2", bucket="my-bucket")
+
+    profile = load_config().get_profile()
+    assert profile.region == "us-west-2"
+    assert profile.bucket == "my-bucket"
+    assert profile.role_arn == "arn:aws:iam::111122223333:role/x"
+    assert profile.stack_name is None
+
+
+def test_initialize_returns_none(capsys):
+    """initialize() is a side-effecting setup function; it shouldn't return data."""
+    result = _initialize_existing()
+    assert result is None
+    # And it should print where the config was saved.
+    assert "Saved profile" in capsys.readouterr().out
+
+
+def test_initialize_requires_role_and_bucket_together():
+    with pytest.raises(ValueError, match="must be provided together"):
+        agc.initialize(role_arn="arn:aws:iam::111122223333:role/x")  # missing bucket
+
+
+def test_initialize_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        agc.initialize(backend="not-a-backend", role_arn="arn:...", bucket="b")
+
+
+def test_initialize_overwrites_existing_profile():
+    """Second initialize() overwrites the first — no confirmation in Python API."""
+    _initialize_existing(bucket="b1")
+    _initialize_existing(bucket="b2")
+    assert load_config().get_profile().bucket == "b2"
+
+
+# ---------------------------------------------------------------------------
+# status
+# ---------------------------------------------------------------------------
+
+
+def test_status_without_config_returns_not_found():
+    result = agc.status()
+    assert result["found"] is False
+    assert "reason" not in result  # missing config, not missing profile
+
+
+def test_status_with_config(monkeypatch):
+    """Status returns a snapshot; health checks are stubbed to avoid AWS."""
+    _initialize_existing()
+    monkeypatch.setattr("autogluon.cloud.cloud_setup._check_bucket", lambda s, b: "ok")
+    monkeypatch.setattr("autogluon.cloud.cloud_setup._check_role", lambda s, r: "ok")
+
+    result = agc.status()
+    assert result["found"] is True
+    assert result["profile_name"] == "default"
+    assert result["is_active"] is True
+    assert result["checks"] == {"bucket": "ok", "role": "ok"}
+
+
+def test_status_missing_profile_returns_structured_result():
+    """Regression: status(profile_name=<nonexistent>) must not raise KeyError."""
+    _initialize_existing()
+    result = agc.status(profile_name="nonexistent")
+    assert result["found"] is False
+    assert result["reason"] == "profile not found"
+    assert result["requested_profile"] == "nonexistent"
+    assert result["available_profiles"] == ["default"]
+
+
+def test_status_check_role_false_skips_iam(monkeypatch):
+    _initialize_existing()
+    monkeypatch.setattr("autogluon.cloud.cloud_setup._check_bucket", lambda s, b: "ok")
+
+    result = agc.status(check_role=False)
+    assert "role" not in result["checks"]
+
+
+# ---------------------------------------------------------------------------
+# teardown
+# ---------------------------------------------------------------------------
+
+
+def test_teardown_without_config_is_noop(capsys):
+    result = agc.teardown()
+    assert result is None
+    assert "nothing to tear down" in capsys.readouterr().out
+
+
+def test_teardown_removes_profile_when_no_stack(capsys):
+    """If the profile has no stack (initialize with role_arn/bucket), teardown is safe."""
+    _initialize_existing()
+    result = agc.teardown()
+    assert result is None
+    assert load_config().profiles == {}
+    assert "no stack to delete" in capsys.readouterr().out
+
+
+def test_teardown_missing_profile_is_friendly(capsys):
+    """Regression: teardown(profile_name=<nonexistent>) must not raise KeyError."""
+    _initialize_existing()
+    result = agc.teardown(profile_name="nonexistent")
+    assert result is None
+    assert "not found" in capsys.readouterr().out
+
+
+def test_teardown_with_stack_hits_cfn(monkeypatch):
+    """When a profile has a stack_name, teardown calls cfn.delete_stack."""
+    _initialize_existing()
+
+    # Promote the profile to having a fake stack.
+    config = load_config()
+    config.get_profile().stack_name = "ag-cloud-sagemaker"
+    save_config(config)
+
+    calls = []
+
+    class FakeWaiter:
+        def wait(self, **kwargs):
+            pass
+
+    class FakeCFN:
+        def delete_stack(self, StackName):
+            calls.append(StackName)
+
+        def get_waiter(self, name):
+            assert name == "stack_delete_complete"
+            return FakeWaiter()
+
+    class FakeSession:
+        def client(self, service):
+            assert service == "cloudformation"
+            return FakeCFN()
+
+        def resource(self, service):
+            raise AssertionError("delete_bucket_contents is False; resource() not expected")
+
+    monkeypatch.setattr(
+        "autogluon.cloud.cloud_setup._boto_session",
+        lambda aws_profile=None, region=None: FakeSession(),
+    )
+
+    agc.teardown()
+    assert calls == ["ag-cloud-sagemaker"]
+    assert load_config().profiles == {}

--- a/tests/unittests/general/test_cloud_setup.py
+++ b/tests/unittests/general/test_cloud_setup.py
@@ -3,7 +3,13 @@
 import pytest
 
 from autogluon.cloud import bootstrap, register, status, teardown
-from autogluon.cloud.config import CONFIG_DIR_ENV, CloudConfig, load_config, save_config
+from autogluon.cloud.config import (
+    CONFIG_DIR_ENV,
+    BackendConfig,
+    CloudConfig,
+    load_config,
+    save_config,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -12,47 +18,64 @@ def isolated_config_dir(tmp_path, monkeypatch):
     yield tmp_path
 
 
-def _register_default():
+def _register_default(backend="sagemaker"):
     register(
-        role_arn="arn:aws:iam::111122223333:role/x",
+        role="arn:aws:iam::111122223333:role/x",
         bucket="b1",
         region="us-east-1",
+        backend=backend,
     )
 
 
 # ---------------------------------------------------------------------------
-# register (no AWS calls — pure file I/O)
+# register
 # ---------------------------------------------------------------------------
 
 
 def test_register_writes_file(capsys):
     _register_default()
 
-    config = load_config()
-    assert config.role_arn == "arn:aws:iam::111122223333:role/x"
-    assert config.bucket == "b1"
-    assert config.region == "us-east-1"
-    assert config.backend == "sagemaker"
-    assert config.stack_name is None
-    assert "Saved AG-Cloud config" in capsys.readouterr().out
+    cfg = load_config()
+    assert "sagemaker" in cfg.backends
+    sage = cfg.backends["sagemaker"]
+    assert sage.role_arn == "arn:aws:iam::111122223333:role/x"
+    assert sage.bucket == "b1"
+    assert sage.region == "us-east-1"
+    assert sage.stack_name is None
+    assert "Saved AG-Cloud config for backend 'sagemaker'" in capsys.readouterr().out
 
 
-def test_register_overwrites_existing():
+def test_register_overwrites_same_backend():
     _register_default()
     register(
-        role_arn="arn:aws:iam::111122223333:role/y",
+        role="arn:aws:iam::111122223333:role/y",
         bucket="b2",
         region="us-west-2",
     )
-    config = load_config()
-    assert config.bucket == "b2"
-    assert config.region == "us-west-2"
+    cfg = load_config()
+    assert cfg.backends["sagemaker"].bucket == "b2"
+    assert cfg.backends["sagemaker"].region == "us-west-2"
+
+
+def test_register_keeps_other_backends_untouched():
+    """Adding ray_aws shouldn't disturb sagemaker."""
+    _register_default(backend="sagemaker")
+    register(
+        role="arn:aws:iam::111122223333:role/r",
+        bucket="ray-bucket",
+        region="us-east-1",
+        backend="ray_aws",
+    )
+    cfg = load_config()
+    assert set(cfg.backends) == {"sagemaker", "ray_aws"}
+    assert cfg.backends["sagemaker"].bucket == "b1"
+    assert cfg.backends["ray_aws"].bucket == "ray-bucket"
 
 
 def test_register_rejects_unknown_backend():
     with pytest.raises(ValueError, match="Unsupported backend"):
         register(
-            role_arn="arn:...",
+            role="arn:...",
             bucket="b",
             region="us-east-1",
             backend="not-a-backend",
@@ -60,14 +83,13 @@ def test_register_rejects_unknown_backend():
 
 
 def test_register_records_stack_name_when_given():
-    """Users who deployed their own stack can record the name so teardown can clean up."""
     register(
-        role_arn="arn:aws:iam::111122223333:role/x",
+        role="arn:aws:iam::111122223333:role/x",
         bucket="b1",
         region="us-east-1",
         stack_name="my-stack",
     )
-    assert load_config().stack_name == "my-stack"
+    assert load_config().backends["sagemaker"].stack_name == "my-stack"
 
 
 # ---------------------------------------------------------------------------
@@ -76,8 +98,6 @@ def test_register_records_stack_name_when_given():
 
 
 def test_bootstrap_calls_cfn_then_registers(monkeypatch, capsys):
-    """bootstrap should deploy a stack and persist outputs via register."""
-
     class FakeSession:
         region_name = "us-east-1"
 
@@ -95,18 +115,15 @@ def test_bootstrap_calls_cfn_then_registers(monkeypatch, capsys):
 
     bootstrap(backend="sagemaker", stack_name="my-stack")
 
-    config = load_config()
-    assert config.role_arn == "arn:aws:iam::123:role/r"
-    assert config.bucket == "ag-cloud-bucket"
-    assert config.stack_name == "my-stack"
-    assert config.region == "us-east-1"
+    cfg = load_config()
+    assert cfg.backends["sagemaker"].role_arn == "arn:aws:iam::123:role/r"
+    assert cfg.backends["sagemaker"].bucket == "ag-cloud-bucket"
+    assert cfg.backends["sagemaker"].stack_name == "my-stack"
 
     out = capsys.readouterr().out
     assert "Deploying CloudFormation stack 'my-stack'" in out
     assert "account 123456789012" in out
-    assert "region us-east-1" in out
     assert "deployed" in out
-    assert "Saved AG-Cloud config" in out
 
 
 def test_bootstrap_returns_none(monkeypatch):
@@ -151,32 +168,35 @@ def test_bootstrap_default_stack_name_uses_backend(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
-def test_status_without_config_returns_not_found():
-    result = status()
-    assert result["found"] is False
+def test_status_without_config_returns_empty_dict():
+    assert status() == {}
 
 
-def test_status_with_config(monkeypatch):
-    _register_default()
+def test_status_returns_one_per_backend(monkeypatch):
+    _register_default(backend="sagemaker")
+    register(
+        role="arn:...",
+        bucket="ray-bucket",
+        region="us-east-1",
+        backend="ray_aws",
+    )
     monkeypatch.setattr("autogluon.cloud.cloud_setup._check_bucket", lambda s, b: "ok")
     monkeypatch.setattr("autogluon.cloud.cloud_setup._check_role", lambda s, r: "ok")
 
-    result = status()
-    assert result["found"] is True
-    assert isinstance(result["config"], CloudConfig)
-    assert result["checks"] == {"bucket": "ok", "role": "ok"}
-
-
-def test_status_check_role_false_skips_iam(monkeypatch):
-    _register_default()
-    monkeypatch.setattr("autogluon.cloud.cloud_setup._check_bucket", lambda s, b: "ok")
-
-    result = status(check_role=False)
-    assert "role" not in result["checks"]
+    reports = status()
+    assert set(reports) == {"sagemaker", "ray_aws"}
+    assert isinstance(reports["sagemaker"].config, BackendConfig)
+    assert reports["sagemaker"].checks == {"bucket": "ok", "role": "ok"}
+    assert reports["ray_aws"].config.bucket == "ray-bucket"
 
 
 def test_status_includes_stack_check_when_stack_name_set(monkeypatch):
-    register(role_arn="arn:...", bucket="b", region="us-east-1", stack_name="s")
+    register(
+        role="arn:...",
+        bucket="b",
+        region="us-east-1",
+        stack_name="s",
+    )
     monkeypatch.setattr("autogluon.cloud.cloud_setup._check_bucket", lambda s, b: "ok")
     monkeypatch.setattr("autogluon.cloud.cloud_setup._check_role", lambda s, r: "ok")
     monkeypatch.setattr(
@@ -184,8 +204,27 @@ def test_status_includes_stack_check_when_stack_name_set(monkeypatch):
         lambda s, n: "CREATE_COMPLETE",
     )
 
-    result = status()
-    assert result["checks"]["stack"] == "CREATE_COMPLETE"
+    reports = status()
+    assert reports["sagemaker"].checks["stack"] == "CREATE_COMPLETE"
+
+
+def test_check_role_returns_unverified_on_access_denied():
+    """AccessDenied means the caller lacks permission to verify, not that the role is broken."""
+    from botocore.exceptions import ClientError
+
+    from autogluon.cloud.cloud_setup import _check_role
+
+    class FakeIAM:
+        def get_role(self, RoleName):
+            raise ClientError({"Error": {"Code": "AccessDenied", "Message": "no perms"}}, "GetRole")
+
+    class FakeSession:
+        def client(self, service):
+            assert service == "iam"
+            return FakeIAM()
+
+    result = _check_role(FakeSession(), "arn:aws:iam::123:role/x")
+    assert "unverified" in result
 
 
 # ---------------------------------------------------------------------------
@@ -198,24 +237,37 @@ def test_teardown_without_config_is_noop(capsys):
     assert "nothing to tear down" in capsys.readouterr().out
 
 
-def test_teardown_no_stack_just_removes_config(capsys):
+def test_teardown_no_stacks_just_removes_config(capsys):
+    """Backends registered without stack_name → only the config is removed."""
     _register_default()
     teardown()
     assert load_config() is None
-    assert "no stack to delete" in capsys.readouterr().out
+    out = capsys.readouterr().out
+    assert "no stack to delete" in out
+    assert "Removed config" in out
 
 
-def test_teardown_with_stack_deletes_stack(monkeypatch):
+def test_teardown_with_stack_deletes_each_backend(monkeypatch):
+    """Multiple backends with stacks → all get deleted, then config removed."""
     save_config(
         CloudConfig(
-            region="us-east-1",
-            role_arn="arn:...",
-            bucket="b",
-            backend="sagemaker",
-            stack_name="ag-cloud-sagemaker",
+            backends={
+                "sagemaker": BackendConfig(
+                    region="us-east-1",
+                    role_arn="arn:...",
+                    bucket="b1",
+                    stack_name="ag-cloud-sagemaker",
+                ),
+                "ray_aws": BackendConfig(
+                    region="us-east-1",
+                    role_arn="arn:...",
+                    bucket="b2",
+                    stack_name="ag-cloud-ray-aws",
+                ),
+            }
         )
     )
-    calls = []
+    deleted = []
 
     class FakeWaiter:
         def wait(self, **kw):
@@ -223,7 +275,7 @@ def test_teardown_with_stack_deletes_stack(monkeypatch):
 
     class FakeCFN:
         def delete_stack(self, StackName):
-            calls.append(StackName)
+            deleted.append(StackName)
 
         def get_waiter(self, name):
             assert name == "stack_delete_complete"
@@ -241,9 +293,26 @@ def test_teardown_with_stack_deletes_stack(monkeypatch):
                 return FakeSTS()
             raise AssertionError(f"unexpected client: {service}")
 
-        def resource(self, service):
-            raise AssertionError("delete_bucket_contents=False; resource() not expected")
-
     teardown(session=FakeSession())
-    assert calls == ["ag-cloud-sagemaker"]
+    assert sorted(deleted) == ["ag-cloud-ray-aws", "ag-cloud-sagemaker"]
     assert load_config() is None
+
+
+def test_teardown_specific_backend_keeps_others():
+    """teardown(backend='sagemaker') removes only that entry; ray_aws stays."""
+    _register_default(backend="sagemaker")
+    register(role="arn:...", bucket="ray-bucket", region="us-east-1", backend="ray_aws")
+
+    teardown(backend="sagemaker")  # neither has a stack_name → no AWS calls
+
+    cfg = load_config()
+    assert cfg is not None
+    assert set(cfg.backends) == {"ray_aws"}
+
+
+def test_teardown_unknown_backend_is_friendly(capsys):
+    _register_default(backend="sagemaker")
+    teardown(backend="ray_aws")  # not registered
+    out = capsys.readouterr().out
+    assert "not in config" in out
+    assert load_config() is not None  # nothing was removed

--- a/tests/unittests/general/test_cloud_setup.py
+++ b/tests/unittests/general/test_cloud_setup.py
@@ -1,9 +1,9 @@
-"""Tests for the top-level Python API (autogluon.cloud.initialize/status/teardown)."""
+"""Tests for the ``autogluon.cloud`` setup API."""
 
 import pytest
 
-import autogluon.cloud as agc
-from autogluon.cloud.config import CONFIG_DIR_ENV, load_config, save_config
+from autogluon.cloud import bootstrap, register, status, teardown
+from autogluon.cloud.config import CONFIG_DIR_ENV, CloudConfig, load_config, save_config
 
 
 @pytest.fixture(autouse=True)
@@ -12,70 +12,138 @@ def isolated_config_dir(tmp_path, monkeypatch):
     yield tmp_path
 
 
-@pytest.fixture(autouse=True)
-def stub_aws(monkeypatch):
-    """Stub out the credential-verification call so tests don't hit AWS."""
+def _register_default():
+    register(
+        role_arn="arn:aws:iam::111122223333:role/x",
+        bucket="b1",
+        region="us-east-1",
+    )
 
-    class _StubSession:
-        def __init__(self, region):
-            self.region_name = region or "us-east-1"
+
+# ---------------------------------------------------------------------------
+# register (no AWS calls — pure file I/O)
+# ---------------------------------------------------------------------------
+
+
+def test_register_writes_file(capsys):
+    _register_default()
+
+    config = load_config()
+    assert config.role_arn == "arn:aws:iam::111122223333:role/x"
+    assert config.bucket == "b1"
+    assert config.region == "us-east-1"
+    assert config.backend == "sagemaker"
+    assert config.stack_name is None
+    assert "Saved AG-Cloud config" in capsys.readouterr().out
+
+
+def test_register_overwrites_existing():
+    _register_default()
+    register(
+        role_arn="arn:aws:iam::111122223333:role/y",
+        bucket="b2",
+        region="us-west-2",
+    )
+    config = load_config()
+    assert config.bucket == "b2"
+    assert config.region == "us-west-2"
+
+
+def test_register_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="Unsupported backend"):
+        register(
+            role_arn="arn:...",
+            bucket="b",
+            region="us-east-1",
+            backend="not-a-backend",
+        )
+
+
+def test_register_records_stack_name_when_given():
+    """Users who deployed their own stack can record the name so teardown can clean up."""
+    register(
+        role_arn="arn:aws:iam::111122223333:role/x",
+        bucket="b1",
+        region="us-east-1",
+        stack_name="my-stack",
+    )
+    assert load_config().stack_name == "my-stack"
+
+
+# ---------------------------------------------------------------------------
+# bootstrap (CFN deploy + register)
+# ---------------------------------------------------------------------------
+
+
+def test_bootstrap_calls_cfn_then_registers(monkeypatch, capsys):
+    """bootstrap should deploy a stack and persist outputs via register."""
+
+    class FakeSession:
+        region_name = "us-east-1"
+
+        def client(self, service):
+            raise AssertionError("session.client unused; _provision_stack is stubbed")
 
     monkeypatch.setattr(
         "autogluon.cloud.cloud_setup._verified_session",
-        lambda aws_profile=None, region=None: _StubSession(region),
+        lambda s: (FakeSession(), "123456789012"),
+    )
+    monkeypatch.setattr(
+        "autogluon.cloud.cloud_setup._provision_stack",
+        lambda session, stack_name, backend: ("arn:aws:iam::123:role/r", "ag-cloud-bucket"),
     )
 
+    bootstrap(backend="sagemaker", stack_name="my-stack")
 
-def _initialize_existing(**overrides):
-    kwargs = dict(
-        backend="sagemaker",
-        region="us-east-1",
-        role_arn="arn:aws:iam::111122223333:role/x",
-        bucket="b1",
+    config = load_config()
+    assert config.role_arn == "arn:aws:iam::123:role/r"
+    assert config.bucket == "ag-cloud-bucket"
+    assert config.stack_name == "my-stack"
+    assert config.region == "us-east-1"
+
+    out = capsys.readouterr().out
+    assert "Deploying CloudFormation stack 'my-stack'" in out
+    assert "account 123456789012" in out
+    assert "region us-east-1" in out
+    assert "deployed" in out
+    assert "Saved AG-Cloud config" in out
+
+
+def test_bootstrap_returns_none(monkeypatch):
+    monkeypatch.setattr(
+        "autogluon.cloud.cloud_setup._verified_session",
+        lambda s: (type("S", (), {"region_name": "us-east-1"})(), "123456789012"),
     )
-    kwargs.update(overrides)
-    agc.initialize(**kwargs)
+    monkeypatch.setattr(
+        "autogluon.cloud.cloud_setup._provision_stack",
+        lambda session, stack_name, backend: ("arn:...", "b"),
+    )
+    assert bootstrap() is None
 
 
-# ---------------------------------------------------------------------------
-# initialize
-# ---------------------------------------------------------------------------
-
-
-def test_initialize_with_existing_resources_writes_config():
-    """`initialize(role_arn=..., bucket=...)` writes config without CloudFormation."""
-    _initialize_existing(region="us-west-2", bucket="my-bucket")
-
-    profile = load_config().get_profile()
-    assert profile.region == "us-west-2"
-    assert profile.bucket == "my-bucket"
-    assert profile.role_arn == "arn:aws:iam::111122223333:role/x"
-    assert profile.stack_name is None
-
-
-def test_initialize_returns_none(capsys):
-    """initialize() is a side-effecting setup function; it shouldn't return data."""
-    result = _initialize_existing()
-    assert result is None
-    # And it should print where the config was saved.
-    assert "Saved profile" in capsys.readouterr().out
-
-
-def test_initialize_requires_role_and_bucket_together():
-    with pytest.raises(ValueError, match="must be provided together"):
-        agc.initialize(role_arn="arn:aws:iam::111122223333:role/x")  # missing bucket
-
-
-def test_initialize_rejects_unknown_backend():
+def test_bootstrap_rejects_unknown_backend():
     with pytest.raises(ValueError, match="Unsupported backend"):
-        agc.initialize(backend="not-a-backend", role_arn="arn:...", bucket="b")
+        bootstrap(backend="not-a-backend")
 
 
-def test_initialize_overwrites_existing_profile():
-    """Second initialize() overwrites the first — no confirmation in Python API."""
-    _initialize_existing(bucket="b1")
-    _initialize_existing(bucket="b2")
-    assert load_config().get_profile().bucket == "b2"
+def test_bootstrap_default_stack_name_uses_backend(monkeypatch):
+    captured = {}
+
+    class FakeSession:
+        region_name = "us-east-1"
+
+    def fake_provision(session, stack_name, backend):
+        captured["stack_name"] = stack_name
+        return "arn:...", "b"
+
+    monkeypatch.setattr(
+        "autogluon.cloud.cloud_setup._verified_session",
+        lambda s: (FakeSession(), "123456789012"),
+    )
+    monkeypatch.setattr("autogluon.cloud.cloud_setup._provision_stack", fake_provision)
+
+    bootstrap(backend="ray_aws")
+    assert captured["stack_name"] == "ag-cloud-ray-aws"
 
 
 # ---------------------------------------------------------------------------
@@ -84,40 +152,40 @@ def test_initialize_overwrites_existing_profile():
 
 
 def test_status_without_config_returns_not_found():
-    result = agc.status()
+    result = status()
     assert result["found"] is False
-    assert "reason" not in result  # missing config, not missing profile
 
 
 def test_status_with_config(monkeypatch):
-    """Status returns a snapshot; health checks are stubbed to avoid AWS."""
-    _initialize_existing()
+    _register_default()
     monkeypatch.setattr("autogluon.cloud.cloud_setup._check_bucket", lambda s, b: "ok")
     monkeypatch.setattr("autogluon.cloud.cloud_setup._check_role", lambda s, r: "ok")
 
-    result = agc.status()
+    result = status()
     assert result["found"] is True
-    assert result["profile_name"] == "default"
-    assert result["is_active"] is True
+    assert isinstance(result["config"], CloudConfig)
     assert result["checks"] == {"bucket": "ok", "role": "ok"}
 
 
-def test_status_missing_profile_returns_structured_result():
-    """Regression: status(profile_name=<nonexistent>) must not raise KeyError."""
-    _initialize_existing()
-    result = agc.status(profile_name="nonexistent")
-    assert result["found"] is False
-    assert result["reason"] == "profile not found"
-    assert result["requested_profile"] == "nonexistent"
-    assert result["available_profiles"] == ["default"]
-
-
 def test_status_check_role_false_skips_iam(monkeypatch):
-    _initialize_existing()
+    _register_default()
     monkeypatch.setattr("autogluon.cloud.cloud_setup._check_bucket", lambda s, b: "ok")
 
-    result = agc.status(check_role=False)
+    result = status(check_role=False)
     assert "role" not in result["checks"]
+
+
+def test_status_includes_stack_check_when_stack_name_set(monkeypatch):
+    register(role_arn="arn:...", bucket="b", region="us-east-1", stack_name="s")
+    monkeypatch.setattr("autogluon.cloud.cloud_setup._check_bucket", lambda s, b: "ok")
+    monkeypatch.setattr("autogluon.cloud.cloud_setup._check_role", lambda s, r: "ok")
+    monkeypatch.setattr(
+        "autogluon.cloud.cloud_setup._check_stack",
+        lambda s, n: "CREATE_COMPLETE",
+    )
+
+    result = status()
+    assert result["checks"]["stack"] == "CREATE_COMPLETE"
 
 
 # ---------------------------------------------------------------------------
@@ -126,41 +194,31 @@ def test_status_check_role_false_skips_iam(monkeypatch):
 
 
 def test_teardown_without_config_is_noop(capsys):
-    result = agc.teardown()
-    assert result is None
+    assert teardown() is None
     assert "nothing to tear down" in capsys.readouterr().out
 
 
-def test_teardown_removes_profile_when_no_stack(capsys):
-    """If the profile has no stack (initialize with role_arn/bucket), teardown is safe."""
-    _initialize_existing()
-    result = agc.teardown()
-    assert result is None
-    assert load_config().profiles == {}
+def test_teardown_no_stack_just_removes_config(capsys):
+    _register_default()
+    teardown()
+    assert load_config() is None
     assert "no stack to delete" in capsys.readouterr().out
 
 
-def test_teardown_missing_profile_is_friendly(capsys):
-    """Regression: teardown(profile_name=<nonexistent>) must not raise KeyError."""
-    _initialize_existing()
-    result = agc.teardown(profile_name="nonexistent")
-    assert result is None
-    assert "not found" in capsys.readouterr().out
-
-
-def test_teardown_with_stack_hits_cfn(monkeypatch):
-    """When a profile has a stack_name, teardown calls cfn.delete_stack."""
-    _initialize_existing()
-
-    # Promote the profile to having a fake stack.
-    config = load_config()
-    config.get_profile().stack_name = "ag-cloud-sagemaker"
-    save_config(config)
-
+def test_teardown_with_stack_deletes_stack(monkeypatch):
+    save_config(
+        CloudConfig(
+            region="us-east-1",
+            role_arn="arn:...",
+            bucket="b",
+            backend="sagemaker",
+            stack_name="ag-cloud-sagemaker",
+        )
+    )
     calls = []
 
     class FakeWaiter:
-        def wait(self, **kwargs):
+        def wait(self, **kw):
             pass
 
     class FakeCFN:
@@ -171,19 +229,21 @@ def test_teardown_with_stack_hits_cfn(monkeypatch):
             assert name == "stack_delete_complete"
             return FakeWaiter()
 
+    class FakeSTS:
+        def get_caller_identity(self):
+            return {"Account": "123456789012"}
+
     class FakeSession:
         def client(self, service):
-            assert service == "cloudformation"
-            return FakeCFN()
+            if service == "cloudformation":
+                return FakeCFN()
+            if service == "sts":
+                return FakeSTS()
+            raise AssertionError(f"unexpected client: {service}")
 
         def resource(self, service):
-            raise AssertionError("delete_bucket_contents is False; resource() not expected")
+            raise AssertionError("delete_bucket_contents=False; resource() not expected")
 
-    monkeypatch.setattr(
-        "autogluon.cloud.cloud_setup._boto_session",
-        lambda aws_profile=None, region=None: FakeSession(),
-    )
-
-    agc.teardown()
+    teardown(session=FakeSession())
     assert calls == ["ag-cloud-sagemaker"]
-    assert load_config().profiles == {}
+    assert load_config() is None

--- a/tests/unittests/general/test_config.py
+++ b/tests/unittests/general/test_config.py
@@ -1,0 +1,101 @@
+import os
+
+import pytest
+import yaml
+
+from autogluon.cloud.config import (
+    CONFIG_DIR_ENV,
+    CloudConfig,
+    Profile,
+    delete_profile,
+    get_config_path,
+    load_config,
+    save_config,
+    upsert_profile,
+)
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    yield tmp_path
+
+
+def _make_profile(**overrides):
+    defaults = dict(
+        region="us-east-1",
+        role_arn="arn:aws:iam::123456789012:role/ag-cloud-execution-role",
+        bucket="ag-cloud-bucket-abc",
+        backend="sagemaker",
+        stack_name="ag-cloud",
+    )
+    defaults.update(overrides)
+    return Profile(**defaults)
+
+
+def test_load_config_missing_returns_none():
+    assert load_config() is None
+
+
+def test_save_load_roundtrip():
+    profile = _make_profile()
+    config = CloudConfig(active_profile="default", profiles={"default": profile})
+    save_config(config)
+
+    loaded = load_config()
+    assert loaded is not None
+    assert loaded.active_profile == "default"
+    assert loaded.profiles["default"].bucket == profile.bucket
+    assert loaded.profiles["default"].role_arn == profile.role_arn
+
+
+def test_saved_file_is_user_only_readable(isolated_config_dir):
+    save_config(CloudConfig(profiles={"default": _make_profile()}))
+    path = get_config_path()
+    mode = os.stat(path).st_mode & 0o777
+    # 0o600 — user read/write, nothing for group/other.
+    assert mode == 0o600
+
+
+def test_upsert_profile_sets_active_for_first_profile():
+    upsert_profile("prod", _make_profile())
+    config = load_config()
+    assert config.active_profile == "prod"
+
+
+def test_upsert_profile_can_switch_active():
+    upsert_profile("dev", _make_profile())
+    upsert_profile("prod", _make_profile(), set_active=True)
+    config = load_config()
+    assert config.active_profile == "prod"
+    assert set(config.profiles) == {"dev", "prod"}
+
+
+def test_delete_profile_falls_back_to_first_remaining():
+    upsert_profile("dev", _make_profile())
+    upsert_profile("prod", _make_profile(), set_active=True)
+    assert delete_profile("prod") is True
+    config = load_config()
+    assert "prod" not in config.profiles
+    assert config.active_profile == "dev"
+
+
+def test_delete_profile_returns_false_when_missing():
+    assert delete_profile("nope") is False
+
+
+def test_get_profile_respects_env_override(monkeypatch):
+    upsert_profile("default", _make_profile(region="us-east-1"))
+    upsert_profile("other", _make_profile(region="us-west-2"), set_active=False)
+    monkeypatch.setenv("AUTOGLUON_CLOUD_PROFILE", "other")
+    config = load_config()
+    assert config.get_profile().region == "us-west-2"
+
+
+def test_config_file_is_yaml(isolated_config_dir):
+    upsert_profile("default", _make_profile())
+    with open(get_config_path()) as f:
+        data = yaml.safe_load(f)
+    assert data["version"] == 1
+    assert "default" in data["profiles"]
+    assert data["profiles"]["default"]["bucket"] == "ag-cloud-bucket-abc"

--- a/tests/unittests/general/test_config.py
+++ b/tests/unittests/general/test_config.py
@@ -5,6 +5,7 @@ import yaml
 
 from autogluon.cloud.config import (
     CONFIG_DIR_ENV,
+    BackendConfig,
     CloudConfig,
     delete_config,
     get_config_path,
@@ -19,16 +20,15 @@ def isolated_config_dir(tmp_path, monkeypatch):
     yield tmp_path
 
 
-def _make_config(**overrides):
+def _make_backend_config(**overrides):
     defaults = dict(
         region="us-east-1",
         role_arn="arn:aws:iam::123456789012:role/ag-cloud-execution-role",
         bucket="ag-cloud-bucket-abc",
-        backend="sagemaker",
         stack_name="ag-cloud",
     )
     defaults.update(overrides)
-    return CloudConfig(**defaults)
+    return BackendConfig(**defaults)
 
 
 def test_load_config_missing_returns_none():
@@ -36,33 +36,47 @@ def test_load_config_missing_returns_none():
 
 
 def test_save_load_roundtrip():
-    config = _make_config()
+    config = CloudConfig(backends={"sagemaker": _make_backend_config()})
     save_config(config)
 
     loaded = load_config()
     assert loaded is not None
-    assert loaded.region == config.region
-    assert loaded.role_arn == config.role_arn
-    assert loaded.bucket == config.bucket
-    assert loaded.backend == config.backend
-    assert loaded.stack_name == config.stack_name
+    assert "sagemaker" in loaded.backends
+    sage = loaded.backends["sagemaker"]
+    assert sage.region == "us-east-1"
+    assert sage.bucket == "ag-cloud-bucket-abc"
+
+
+def test_save_supports_multiple_backends():
+    config = CloudConfig(
+        backends={
+            "sagemaker": _make_backend_config(bucket="sage-bucket"),
+            "ray_aws": _make_backend_config(bucket="ray-bucket", stack_name="ag-cloud-ray"),
+        }
+    )
+    save_config(config)
+
+    loaded = load_config()
+    assert set(loaded.backends) == {"sagemaker", "ray_aws"}
+    assert loaded.backends["sagemaker"].bucket == "sage-bucket"
+    assert loaded.backends["ray_aws"].bucket == "ray-bucket"
 
 
 def test_saved_file_is_user_only_readable():
-    save_config(_make_config())
+    save_config(CloudConfig(backends={"sagemaker": _make_backend_config()}))
     mode = os.stat(get_config_path()).st_mode & 0o777
     # 0o600 — user read/write, nothing for group/other.
     assert mode == 0o600
 
 
 def test_save_overwrites_previous():
-    save_config(_make_config(bucket="b1"))
-    save_config(_make_config(bucket="b2"))
-    assert load_config().bucket == "b2"
+    save_config(CloudConfig(backends={"sagemaker": _make_backend_config(bucket="b1")}))
+    save_config(CloudConfig(backends={"sagemaker": _make_backend_config(bucket="b2")}))
+    assert load_config().backends["sagemaker"].bucket == "b2"
 
 
 def test_delete_config_removes_file():
-    save_config(_make_config())
+    save_config(CloudConfig(backends={"sagemaker": _make_backend_config()}))
     assert delete_config() is True
     assert load_config() is None
 
@@ -71,15 +85,17 @@ def test_delete_config_returns_false_when_missing():
     assert delete_config() is False
 
 
-def test_config_file_is_yaml():
-    save_config(_make_config())
+def test_config_file_is_keyed_by_backend():
+    save_config(CloudConfig(backends={"sagemaker": _make_backend_config()}))
     with open(get_config_path()) as f:
         data = yaml.safe_load(f)
-    assert data["bucket"] == "ag-cloud-bucket-abc"
-    assert data["region"] == "us-east-1"
+    # Top-level keys are backend names; per-backend dict has the resource fields.
+    assert list(data.keys()) == ["sagemaker"]
+    assert data["sagemaker"]["bucket"] == "ag-cloud-bucket-abc"
+    assert data["sagemaker"]["region"] == "us-east-1"
 
 
-def test_load_config_handles_empty_file(isolated_config_dir):
+def test_load_config_handles_empty_file():
     """A file that exists but is empty should be treated as missing."""
     path = get_config_path()
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/unittests/general/test_config.py
+++ b/tests/unittests/general/test_config.py
@@ -6,12 +6,10 @@ import yaml
 from autogluon.cloud.config import (
     CONFIG_DIR_ENV,
     CloudConfig,
-    Profile,
-    delete_profile,
+    delete_config,
     get_config_path,
     load_config,
     save_config,
-    upsert_profile,
 )
 
 
@@ -21,7 +19,7 @@ def isolated_config_dir(tmp_path, monkeypatch):
     yield tmp_path
 
 
-def _make_profile(**overrides):
+def _make_config(**overrides):
     defaults = dict(
         region="us-east-1",
         role_arn="arn:aws:iam::123456789012:role/ag-cloud-execution-role",
@@ -30,7 +28,7 @@ def _make_profile(**overrides):
         stack_name="ag-cloud",
     )
     defaults.update(overrides)
-    return Profile(**defaults)
+    return CloudConfig(**defaults)
 
 
 def test_load_config_missing_returns_none():
@@ -38,64 +36,52 @@ def test_load_config_missing_returns_none():
 
 
 def test_save_load_roundtrip():
-    profile = _make_profile()
-    config = CloudConfig(active_profile="default", profiles={"default": profile})
+    config = _make_config()
     save_config(config)
 
     loaded = load_config()
     assert loaded is not None
-    assert loaded.active_profile == "default"
-    assert loaded.profiles["default"].bucket == profile.bucket
-    assert loaded.profiles["default"].role_arn == profile.role_arn
+    assert loaded.region == config.region
+    assert loaded.role_arn == config.role_arn
+    assert loaded.bucket == config.bucket
+    assert loaded.backend == config.backend
+    assert loaded.stack_name == config.stack_name
 
 
-def test_saved_file_is_user_only_readable(isolated_config_dir):
-    save_config(CloudConfig(profiles={"default": _make_profile()}))
-    path = get_config_path()
-    mode = os.stat(path).st_mode & 0o777
+def test_saved_file_is_user_only_readable():
+    save_config(_make_config())
+    mode = os.stat(get_config_path()).st_mode & 0o777
     # 0o600 — user read/write, nothing for group/other.
     assert mode == 0o600
 
 
-def test_upsert_profile_sets_active_for_first_profile():
-    upsert_profile("prod", _make_profile())
-    config = load_config()
-    assert config.active_profile == "prod"
+def test_save_overwrites_previous():
+    save_config(_make_config(bucket="b1"))
+    save_config(_make_config(bucket="b2"))
+    assert load_config().bucket == "b2"
 
 
-def test_upsert_profile_can_switch_active():
-    upsert_profile("dev", _make_profile())
-    upsert_profile("prod", _make_profile(), set_active=True)
-    config = load_config()
-    assert config.active_profile == "prod"
-    assert set(config.profiles) == {"dev", "prod"}
+def test_delete_config_removes_file():
+    save_config(_make_config())
+    assert delete_config() is True
+    assert load_config() is None
 
 
-def test_delete_profile_falls_back_to_first_remaining():
-    upsert_profile("dev", _make_profile())
-    upsert_profile("prod", _make_profile(), set_active=True)
-    assert delete_profile("prod") is True
-    config = load_config()
-    assert "prod" not in config.profiles
-    assert config.active_profile == "dev"
+def test_delete_config_returns_false_when_missing():
+    assert delete_config() is False
 
 
-def test_delete_profile_returns_false_when_missing():
-    assert delete_profile("nope") is False
-
-
-def test_get_profile_respects_env_override(monkeypatch):
-    upsert_profile("default", _make_profile(region="us-east-1"))
-    upsert_profile("other", _make_profile(region="us-west-2"), set_active=False)
-    monkeypatch.setenv("AUTOGLUON_CLOUD_PROFILE", "other")
-    config = load_config()
-    assert config.get_profile().region == "us-west-2"
-
-
-def test_config_file_is_yaml(isolated_config_dir):
-    upsert_profile("default", _make_profile())
+def test_config_file_is_yaml():
+    save_config(_make_config())
     with open(get_config_path()) as f:
         data = yaml.safe_load(f)
-    assert data["version"] == 1
-    assert "default" in data["profiles"]
-    assert data["profiles"]["default"]["bucket"] == "ag-cloud-bucket-abc"
+    assert data["bucket"] == "ag-cloud-bucket-abc"
+    assert data["region"] == "us-east-1"
+
+
+def test_load_config_handles_empty_file(isolated_config_dir):
+    """A file that exists but is empty should be treated as missing."""
+    path = get_config_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.touch()
+    assert load_config() is None


### PR DESCRIPTION
Introduces `autogluon.cloud.bootstrap/register/status/teardown` Python API. This functionality will be extended to a CLI interface as well using `click` and `rich` in a subsequent PR. Both will use the shared `cloud_setup` engine that provisions the CloudFormation stack, writes a per-profile config at ~/.autogluon/cloud.yaml, and tears it down cleanly.

## Usage

  ```python
  from autogluon.cloud import bootstrap, status, teardown

  bootstrap()       # uses the defaults
  # OR
  bootstrap(backend="sagemaker", session=<boto3 session>, stack_name="my_stack")
  
  status()                                    # health check
  teardown(delete_bucket_contents=True)       # cleanup
  ```

  `bootstrap()` deploys the CloudFormation stack and calls method `register` to save outputs to `~/.autogluon/cloud.yaml`.

---

Follow Up PRs in order:

  - [ ] CLI equivalent (`autogluon-cloud bootstrap/status/teardown`) built on the same setup engine
  - [ ] Wire the config auto-load into `CloudPredictor.__init__` so users don't need to pass `cloud_output_path=` after `bootstrap()`
  - [ ] Update `docs/tutorials/autogluon-cloud.md` to lead with the `agc.initialize()` quick setup; add `init/status/teardown` to `docs/api.rst`


Note: Used opus 4.7 for development, please review carefully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
