### PR TITLE
Fix CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,8 @@ jobs:
 
     # CodeQL runs on ubuntu-latest and windows-latest
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Currently CodeQL action is failing due to insufficient permissions (see e.g. https://github.com/autogluon/autogluon-cloud/actions/runs/25673053729/job/75363211409). This PR fixes this problem

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
