### PR TITLE
Add a skeleton for the foundation model class

### DIFF
--- a/src/autogluon/cloud/model/__init__.py
+++ b/src/autogluon/cloud/model/__init__.py
@@ -1,0 +1,3 @@
+from .foundation_model import FoundationModel, TabularFoundationModel, TimeSeriesFoundationModel
+
+__all__ = ["FoundationModel", "TabularFoundationModel", "TimeSeriesFoundationModel"]

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -162,7 +162,7 @@ class TimeSeriesFoundationModel(FoundationModel):
         timestamp_column: str = "timestamp",
         known_covariates: Optional[Union[str, pd.DataFrame]] = None,
         static_features: Optional[Union[str, pd.DataFrame]] = None,
-        prediction_length: int = 64,
+        prediction_length: int = 1,
         quantile_levels: Optional[List[float]] = None,
         output_path: Optional[str] = None,
         instance_type: Optional[str] = None,

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -1,0 +1,233 @@
+"""FoundationModel — deploy and predict with pretrained foundation models on AWS."""
+
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import Any, Dict, List, Literal, Optional, Union
+
+import pandas as pd
+
+from autogluon.cloud.endpoint.endpoint import Endpoint
+from autogluon.cloud.job.remote_job import RemoteJob
+
+from .registry import get_model_config
+
+
+class FoundationModel:
+    """
+    Pretrained foundation model inference on AWS.
+
+    Factory: FoundationModel("chronos-bolt-base", ...) returns the appropriate
+    task-specific subclass (TimeSeriesFoundationModel, TabularFoundationModel).
+
+    Examples
+    --------
+    >>> model = FoundationModel("chronos-bolt-base", role_arn="arn:...")
+    >>> endpoint = model.deploy()
+    >>> predictions = endpoint.predict(data)
+    >>> endpoint.delete_endpoint()
+    """
+
+    def __new__(cls, model_id: str, **kwargs) -> "FoundationModel":
+        if cls is not FoundationModel:
+            return super().__new__(cls)
+        config = get_model_config(model_id)
+        task = config["task"]
+        if task == "timeseries":
+            return super().__new__(TimeSeriesFoundationModel)
+        elif task == "tabular":
+            return super().__new__(TabularFoundationModel)
+        raise ValueError(f"Unsupported task: {task}")
+
+    def __init__(
+        self,
+        model_id: str,
+        backend: Literal["sagemaker"] = "sagemaker",
+        role_arn: Optional[str] = None,
+        region: Optional[str] = None,
+        s3_output_path: Optional[str] = None,
+        model_config: Optional[Dict[str, Any]] = None,
+    ):
+        self.model_id = model_id
+        self.role_arn = role_arn
+        self.region = region
+        self.s3_output_path = s3_output_path
+        self._config = get_model_config(model_id)
+        # Merge user overrides on top of registry defaults
+        self.model_config = {**self._config.get("model_config", {}), **(model_config or {})}
+        # TODO: instantiate backend via BackendFactory
+        self._backend_type = backend
+
+    def deploy(
+        self,
+        instance_type: Optional[str] = None,
+        mode: Literal["realtime", "serverless", "async"] = "realtime",
+        endpoint_name: Optional[str] = None,
+        model_artifact_path: Optional[str] = None,
+        model_config: Optional[Dict[str, Any]] = None,
+        wait: bool = True,
+    ) -> Endpoint:
+        """
+        Deploy model to an endpoint.
+
+        Parameters
+        ----------
+        instance_type
+            Instance type for the endpoint.
+            If None, will use the default from the model registry.
+        mode
+            Endpoint type.
+        endpoint_name
+            Custom endpoint name.
+            If None, will auto-generate a unique name.
+        model_artifact_path
+            S3 path to pre-cached model weights (for VPC / fast cold start).
+            If None, weights are downloaded from HuggingFace on cold start.
+        model_config
+            Override default inference config (prediction_length, quantile_levels, etc.)
+        wait
+            Whether to block until the endpoint is ready.
+
+        Returns
+        -------
+        Endpoint
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def predict(self, data: Union[str, pd.DataFrame], wait: bool = True, **kwargs) -> Union[pd.DataFrame, RemoteJob]:
+        """Subclasses override with task-specific signature."""
+        ...
+
+    def fit(
+        self,
+        train_data: Union[str, pd.DataFrame],
+        output_path: Optional[str] = None,
+        instance_type: Optional[str] = None,
+        wait: bool = True,
+        **kwargs,
+    ) -> "FoundationModel":
+        """
+        Fine-tune the model. Returns a new FoundationModel pointing to the fine-tuned artifact.
+
+        Parameters
+        ----------
+        train_data
+            Training data as DataFrame or S3 path.
+        output_path
+            S3 path to store fine-tuned model.
+            If None, will auto-generate under s3_output_path.
+        instance_type
+            Instance type for the training job.
+            If None, will use the default from the model registry.
+        wait
+            If True, block until training completes.
+
+        Returns
+        -------
+        FoundationModel
+            New instance with model_config pointing to the fine-tuned artifact.
+        """
+        raise NotImplementedError
+
+    def cache_model_artifact(self, s3_path: str) -> str:
+        """
+        Pre-cache model weights to S3 for VPC or production use.
+
+        Launches a small job that downloads weights from HuggingFace
+        and writes them to S3, avoiding large local downloads.
+
+        Parameters
+        ----------
+        s3_path
+            S3 path where the model weights should be cached.
+
+        Returns
+        -------
+        str
+            S3 path to the cached artifact.
+        """
+        raise NotImplementedError
+
+
+class TimeSeriesFoundationModel(FoundationModel):
+    """Foundation model for time series forecasting (Chronos, etc.)."""
+
+    def predict(
+        self,
+        data: Union[str, pd.DataFrame],
+        known_covariates: Optional[Union[str, pd.DataFrame]] = None,
+        prediction_length: Optional[int] = None,
+        quantile_levels: Optional[List[float]] = None,
+        output_path: Optional[str] = None,
+        instance_type: Optional[str] = None,
+        wait: bool = True,
+    ) -> Union[pd.DataFrame, RemoteJob]:
+        """
+        Run batch prediction for time series.
+
+        Parameters
+        ----------
+        data
+            Historical time series in long format (DataFrame or S3 path).
+        known_covariates
+            Future values of known covariates (DataFrame or S3 path).
+        prediction_length
+            Number of time steps to forecast.
+            If None, will use the default from the model registry.
+        quantile_levels
+            Quantiles to predict.
+            If None, will use the default from the model registry.
+        output_path
+            S3 path to store predictions.
+            If None, will auto-generate under s3_output_path.
+        instance_type
+            Instance type for the prediction job.
+            If None, will use the default from the model registry.
+        wait
+            If True, block and return DataFrame. If False, return the job handle.
+
+        Returns
+        -------
+        Union[pd.DataFrame, RemoteJob]
+        """
+        raise NotImplementedError
+
+
+class TabularFoundationModel(FoundationModel):
+    """Foundation model for tabular prediction (Mitra, TabICL, etc.)."""
+
+    def predict(
+        self,
+        train_data: Union[str, pd.DataFrame],
+        test_data: Union[str, pd.DataFrame],
+        label: str = "target",
+        output_path: Optional[str] = None,
+        instance_type: Optional[str] = None,
+        wait: bool = True,
+    ) -> Union[pd.DataFrame, RemoteJob]:
+        """
+        Run batch prediction for tabular tasks.
+
+        Parameters
+        ----------
+        train_data
+            Labeled few-shot context for the foundation model.
+        test_data
+            Unlabeled data to predict on.
+        label
+            Target column name in train_data.
+        output_path
+            S3 path to store predictions.
+            If None, will auto-generate under s3_output_path.
+        instance_type
+            Instance type for the prediction job.
+            If None, will use the default from the model registry.
+        wait
+            If True, block and return DataFrame. If False, return the job handle.
+
+        Returns
+        -------
+        Union[pd.DataFrame, RemoteJob]
+        """
+        raise NotImplementedError

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -66,7 +66,6 @@ class FoundationModel:
     def deploy(
         self,
         instance_type: Optional[str] = None,
-        mode: Literal["realtime", "serverless", "async"] = "realtime",
         endpoint_name: Optional[str] = None,
         hyperparameters: Optional[Dict[str, Any]] = None,
         wait: bool = True,
@@ -80,8 +79,6 @@ class FoundationModel:
         instance_type
             Instance type for the endpoint.
             If None, will use the default from the model registry.
-        mode
-            Endpoint type.
         endpoint_name
             Custom endpoint name.
             If None, will auto-generate a unique name.
@@ -91,8 +88,8 @@ class FoundationModel:
         wait
             Whether to block until the endpoint is ready.
         **backend_kwargs
-            Additional backend-specific arguments (e.g. framework_version, custom_image_uri,
-            volume_size).
+            Backend-specific arguments. Use these to configure serverless, async, or
+            autoscaling (e.g. memory_size_in_mb, max_concurrency, initial_instance_count).
 
         Returns
         -------

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -135,6 +135,8 @@ class FoundationModel:
         FoundationModel
             New instance with hyperparameters pointing to the fine-tuned artifact.
         """
+        if not self._config.get("fine_tunable", False):
+            raise ValueError(f"Model '{self.model_id}' does not support fine-tuning.")
         raise NotImplementedError
 
     def cache_model_artifact(self, s3_path: str) -> str:

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -33,9 +33,9 @@ class FoundationModel:
             return super().__new__(cls)
         config = get_model_config(model_id)
         task = config["task"]
-        if task == "timeseries":
+        if task == "forecasting":
             return super().__new__(TimeSeriesFoundationModel)
-        elif task == "tabular":
+        elif task in ("classification", "regression"):
             return super().__new__(TabularFoundationModel)
         raise ValueError(f"Unsupported task: {task}")
 
@@ -156,7 +156,11 @@ class TimeSeriesFoundationModel(FoundationModel):
     def predict(
         self,
         data: Union[str, pd.DataFrame],
+        target: str = "target",
+        id_column: str = "item_id",
+        timestamp_column: str = "timestamp",
         known_covariates: Optional[Union[str, pd.DataFrame]] = None,
+        static_features: Optional[Union[str, pd.DataFrame]] = None,
         prediction_length: Optional[int] = None,
         quantile_levels: Optional[List[float]] = None,
         output_path: Optional[str] = None,
@@ -170,8 +174,16 @@ class TimeSeriesFoundationModel(FoundationModel):
         ----------
         data
             Historical time series in long format (DataFrame or S3 path).
+        target
+            Name of the target column to forecast.
+        id_column
+            Name of the item ID column.
+        timestamp_column
+            Name of the timestamp column.
         known_covariates
             Future values of known covariates (DataFrame or S3 path).
+        static_features
+            Metadata attributes of individual items (DataFrame or S3 path).
         prediction_length
             Number of time steps to forecast.
             If None, will use the default from the model registry.
@@ -208,6 +220,41 @@ class TabularFoundationModel(FoundationModel):
     ) -> Union[pd.DataFrame, RemoteJob]:
         """
         Run batch prediction for tabular tasks.
+
+        Parameters
+        ----------
+        train_data
+            Labeled few-shot context for the foundation model.
+        test_data
+            Unlabeled data to predict on.
+        label
+            Target column name in train_data.
+        output_path
+            S3 path to store predictions.
+            If None, will auto-generate under s3_output_path.
+        instance_type
+            Instance type for the prediction job.
+            If None, will use the default from the model registry.
+        wait
+            If True, block and return DataFrame. If False, return the job handle.
+
+        Returns
+        -------
+        Union[pd.DataFrame, RemoteJob]
+        """
+        raise NotImplementedError
+
+    def predict_proba(
+        self,
+        train_data: Union[str, pd.DataFrame],
+        test_data: Union[str, pd.DataFrame],
+        label: str = "target",
+        output_path: Optional[str] = None,
+        instance_type: Optional[str] = None,
+        wait: bool = True,
+    ) -> Union[pd.DataFrame, RemoteJob]:
+        """
+        Run batch prediction returning class probabilities.
 
         Parameters
         ----------

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -54,7 +54,7 @@ class FoundationModel:
         self.s3_output_path = s3_output_path
         self._config = get_model_config(model_id)
         # Merge user overrides on top of registry defaults
-        self.model_config = {**self._config.get("model_config", {}), **(model_config or {})}
+        self.model_config = self._config.get("model_config", {}) | (model_config or {})
         # TODO: instantiate backend via BackendFactory
         self._backend_type = backend
 

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -64,8 +64,8 @@ class FoundationModel:
         mode: Literal["realtime", "serverless", "async"] = "realtime",
         endpoint_name: Optional[str] = None,
         model_artifact_path: Optional[str] = None,
-        model_config: Optional[Dict[str, Any]] = None,
         wait: bool = True,
+        **backend_kwargs,
     ) -> Endpoint:
         """
         Deploy model to an endpoint.
@@ -81,12 +81,13 @@ class FoundationModel:
             Custom endpoint name.
             If None, will auto-generate a unique name.
         model_artifact_path
-            S3 path to pre-cached model weights (for VPC / fast cold start).
-            If None, weights are downloaded from HuggingFace on cold start.
-        model_config
-            Override default inference config (prediction_length, quantile_levels, etc.)
+            S3 path to pre-cached model weights (for VPC use).
+            If None, weights are downloaded from HuggingFace at startup.
         wait
             Whether to block until the endpoint is ready.
+        **backend_kwargs
+            Additional backend-specific arguments (e.g. framework_version, custom_image_uri,
+            volume_size).
 
         Returns
         -------
@@ -132,10 +133,10 @@ class FoundationModel:
 
     def cache_model_artifact(self, s3_path: str) -> str:
         """
-        Pre-cache model weights to S3 for VPC or production use.
+        Pre-cache model weights to S3 (for VPC-deployed endpoints).
 
         Launches a small job that downloads weights from HuggingFace
-        and writes them to S3, avoiding large local downloads.
+        and uploads them to S3.
 
         Parameters
         ----------
@@ -161,11 +162,12 @@ class TimeSeriesFoundationModel(FoundationModel):
         timestamp_column: str = "timestamp",
         known_covariates: Optional[Union[str, pd.DataFrame]] = None,
         static_features: Optional[Union[str, pd.DataFrame]] = None,
-        prediction_length: Optional[int] = None,
+        prediction_length: int = 64,
         quantile_levels: Optional[List[float]] = None,
         output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
         wait: bool = True,
+        **backend_kwargs,
     ) -> Union[pd.DataFrame, RemoteJob]:
         """
         Run batch prediction for time series.
@@ -186,10 +188,8 @@ class TimeSeriesFoundationModel(FoundationModel):
             Metadata attributes of individual items (DataFrame or S3 path).
         prediction_length
             Number of time steps to forecast.
-            If None, will use the default from the model registry.
         quantile_levels
             Quantiles to predict.
-            If None, will use the default from the model registry.
         output_path
             S3 path to store predictions.
             If None, will auto-generate under s3_output_path.
@@ -198,6 +198,9 @@ class TimeSeriesFoundationModel(FoundationModel):
             If None, will use the default from the model registry.
         wait
             If True, block and return DataFrame. If False, return the job handle.
+        **backend_kwargs
+            Additional backend-specific arguments (e.g. job_name, custom_image_uri,
+            framework_version, volume_size).
 
         Returns
         -------
@@ -217,6 +220,7 @@ class TabularFoundationModel(FoundationModel):
         output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
         wait: bool = True,
+        **backend_kwargs,
     ) -> Union[pd.DataFrame, RemoteJob]:
         """
         Run batch prediction for tabular tasks.
@@ -237,6 +241,9 @@ class TabularFoundationModel(FoundationModel):
             If None, will use the default from the model registry.
         wait
             If True, block and return DataFrame. If False, return the job handle.
+        **backend_kwargs
+            Additional backend-specific arguments (e.g. job_name, custom_image_uri,
+            framework_version, volume_size).
 
         Returns
         -------
@@ -252,6 +259,7 @@ class TabularFoundationModel(FoundationModel):
         output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
         wait: bool = True,
+        **backend_kwargs,
     ) -> Union[pd.DataFrame, RemoteJob]:
         """
         Run batch prediction returning class probabilities.
@@ -272,6 +280,9 @@ class TabularFoundationModel(FoundationModel):
             If None, will use the default from the model registry.
         wait
             If True, block and return DataFrame. If False, return the job handle.
+        **backend_kwargs
+            Additional backend-specific arguments (e.g. job_name, custom_image_uri,
+            framework_version, volume_size).
 
         Returns
         -------

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -99,7 +99,12 @@ class FoundationModel:
 
     @abstractmethod
     def predict(self, data: Union[str, pd.DataFrame], wait: bool = True, **kwargs) -> Union[pd.DataFrame, RemoteJob]:
-        """Subclasses override with task-specific signature."""
+        """Subclasses override with task-specific signature.
+
+        When wait=False, returns a RemoteJob handle. Use job.get_job_status() to poll
+        and job.get_output_path() to get the S3 path to predictions once complete.
+        """
+        # TODO: consider adding a .result() method to RemoteJob that downloads + parses output
         ...
 
     def fit(

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -22,7 +22,7 @@ class FoundationModel:
 
     Examples
     --------
-    >>> model = FoundationModel("chronos-bolt-base", role_arn="arn:...")
+    >>> model = FoundationModel("chronos-bolt-base", role_arn="arn:...", hyperparameters={"model_path": "s3://cached/"})
     >>> endpoint = model.deploy()
     >>> predictions = endpoint.predict(data)
     >>> endpoint.delete_endpoint()
@@ -46,24 +46,29 @@ class FoundationModel:
         role_arn: Optional[str] = None,
         region: Optional[str] = None,
         s3_output_path: Optional[str] = None,
-        model_config: Optional[Dict[str, Any]] = None,
+        hyperparameters: Optional[Dict[str, Any]] = None,
     ):
         self.model_id = model_id
         self.role_arn = role_arn
         self.region = region
         self.s3_output_path = s3_output_path
         self._config = get_model_config(model_id)
-        # Merge user overrides on top of registry defaults
-        self.model_config = self._config.get("model_config", {}) | (model_config or {})
+        self._hyperparameter_overrides = hyperparameters or {}
         # TODO: instantiate backend via BackendFactory
         self._backend_type = backend
+
+    def _get_hyperparameters(
+        self, context: Literal["inference", "training"], overrides: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        config_key = "inference_hyperparameters" if context == "inference" else "training_hyperparameters"
+        return self._config.get(config_key, {}) | self._hyperparameter_overrides | (overrides or {})
 
     def deploy(
         self,
         instance_type: Optional[str] = None,
         mode: Literal["realtime", "serverless", "async"] = "realtime",
         endpoint_name: Optional[str] = None,
-        model_artifact_path: Optional[str] = None,
+        hyperparameters: Optional[Dict[str, Any]] = None,
         wait: bool = True,
         **backend_kwargs,
     ) -> Endpoint:
@@ -80,9 +85,9 @@ class FoundationModel:
         endpoint_name
             Custom endpoint name.
             If None, will auto-generate a unique name.
-        model_artifact_path
-            S3 path to pre-cached model weights (for VPC use).
-            If None, weights are downloaded from HuggingFace at startup.
+        hyperparameters
+            Model hyperparameters for inference. Overrides values passed to the constructor.
+            Available hyperparameters for each model are listed in the AutoGluon documentation.
         wait
             Whether to block until the endpoint is ready.
         **backend_kwargs
@@ -105,6 +110,7 @@ class FoundationModel:
         train_data: Union[str, pd.DataFrame],
         output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
+        hyperparameters: Optional[Dict[str, Any]] = None,
         wait: bool = True,
         **kwargs,
     ) -> "FoundationModel":
@@ -121,13 +127,16 @@ class FoundationModel:
         instance_type
             Instance type for the training job.
             If None, will use the default from the model registry.
+        hyperparameters
+            Model hyperparameters for training. Overrides values passed to the constructor.
+            Available hyperparameters for each model are listed in the AutoGluon documentation.
         wait
             If True, block until training completes.
 
         Returns
         -------
         FoundationModel
-            New instance with model_config pointing to the fine-tuned artifact.
+            New instance with hyperparameters pointing to the fine-tuned artifact.
         """
         raise NotImplementedError
 
@@ -164,6 +173,7 @@ class TimeSeriesFoundationModel(FoundationModel):
         static_features: Optional[Union[str, pd.DataFrame]] = None,
         prediction_length: int = 1,
         quantile_levels: Optional[List[float]] = None,
+        hyperparameters: Optional[Dict[str, Any]] = None,
         output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
         wait: bool = True,
@@ -190,6 +200,9 @@ class TimeSeriesFoundationModel(FoundationModel):
             Number of time steps to forecast.
         quantile_levels
             Quantiles to predict.
+        hyperparameters
+            Model hyperparameters for inference. Overrides values passed to the constructor.
+            Available hyperparameters for each model are listed in the AutoGluon documentation.
         output_path
             S3 path to store predictions.
             If None, will auto-generate under s3_output_path.
@@ -217,6 +230,7 @@ class TabularFoundationModel(FoundationModel):
         train_data: Union[str, pd.DataFrame],
         test_data: Union[str, pd.DataFrame],
         label: str = "target",
+        hyperparameters: Optional[Dict[str, Any]] = None,
         output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
         wait: bool = True,
@@ -233,6 +247,9 @@ class TabularFoundationModel(FoundationModel):
             Unlabeled data to predict on.
         label
             Target column name in train_data.
+        hyperparameters
+            Model hyperparameters for inference. Overrides values passed to the constructor.
+            Available hyperparameters for each model are listed in the AutoGluon documentation.
         output_path
             S3 path to store predictions.
             If None, will auto-generate under s3_output_path.
@@ -256,6 +273,7 @@ class TabularFoundationModel(FoundationModel):
         train_data: Union[str, pd.DataFrame],
         test_data: Union[str, pd.DataFrame],
         label: str = "target",
+        hyperparameters: Optional[Dict[str, Any]] = None,
         output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
         wait: bool = True,
@@ -272,6 +290,9 @@ class TabularFoundationModel(FoundationModel):
             Unlabeled data to predict on.
         label
             Target column name in train_data.
+        hyperparameters
+            Model hyperparameters for inference. Overrides values passed to the constructor.
+            Available hyperparameters for each model are listed in the AutoGluon documentation.
         output_path
             S3 path to store predictions.
             If None, will auto-generate under s3_output_path.

--- a/src/autogluon/cloud/model/registry.py
+++ b/src/autogluon/cloud/model/registry.py
@@ -43,19 +43,20 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "training_hyperparameters": {"model_path": "amazon/chronos-2", "fine_tune": True},
         "default_instance_type": "ml.g5.xlarge",
     },
+    # TODO: Replace dummy configs with real values
     "mitra-classification": {
         "task": "classification",
         "model_name": "Mitra",
         "inference_hyperparameters": {"model_path": "TODO"},
         "training_hyperparameters": {"model_path": "TODO"},
-        "default_instance_type": "ml.m5.xlarge",
+        "default_instance_type": "ml.g5.xlarge",
     },
     "mitra-regression": {
         "task": "regression",
         "model_name": "Mitra",
         "inference_hyperparameters": {"model_path": "TODO"},
         "training_hyperparameters": {"model_path": "TODO"},
-        "default_instance_type": "ml.m5.xlarge",
+        "default_instance_type": "ml.g5.xlarge",
     },
 }
 

--- a/src/autogluon/cloud/model/registry.py
+++ b/src/autogluon/cloud/model/registry.py
@@ -7,8 +7,8 @@ from typing import Any, Dict, Literal, TypedDict
 
 
 class FoundationModelConfig(TypedDict):
-    task: Literal["timeseries", "tabular"]
-    model_name: str  # AG model class name (e.g. "Chronos", "Chronos2")
+    task: Literal["forecasting", "classification", "regression"]
+    model_name: str  # AG model class name (e.g. "Chronos", "Chronos2", "Mitra")
     model_config: Dict[str, Any]  # passed to the AG model (e.g. {"model_path": "..."})
     default_instance_type: str
     default_inference_config: Dict[str, Any]  # default prediction kwargs
@@ -16,7 +16,7 @@ class FoundationModelConfig(TypedDict):
 
 FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
     "chronos-bolt-tiny": {
-        "task": "timeseries",
+        "task": "forecasting",
         "model_name": "Chronos",
         "model_config": {"model_path": "amazon/chronos-bolt-tiny"},
         "default_instance_type": "ml.g5.xlarge",
@@ -26,7 +26,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         },
     },
     "chronos-bolt-small": {
-        "task": "timeseries",
+        "task": "forecasting",
         "model_name": "Chronos",
         "model_config": {"model_path": "amazon/chronos-bolt-small"},
         "default_instance_type": "ml.g5.xlarge",
@@ -36,7 +36,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         },
     },
     "chronos-bolt-base": {
-        "task": "timeseries",
+        "task": "forecasting",
         "model_name": "Chronos",
         "model_config": {"model_path": "amazon/chronos-bolt-base"},
         "default_instance_type": "ml.g5.xlarge",
@@ -46,7 +46,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         },
     },
     "chronos-2": {
-        "task": "timeseries",
+        "task": "forecasting",
         "model_name": "Chronos2",
         "model_config": {"model_path": "amazon/chronos-2"},
         "default_instance_type": "ml.g5.xlarge",
@@ -54,6 +54,20 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
             "prediction_length": 64,
             "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
         },
+    },
+    "mitra-classification": {
+        "task": "classification",
+        "model_name": "Mitra",
+        "model_config": {"model_path": "TODO"},
+        "default_instance_type": "ml.m5.xlarge",
+        "default_inference_config": {},
+    },
+    "mitra-regression": {
+        "task": "regression",
+        "model_name": "Mitra",
+        "model_config": {"model_path": "TODO"},
+        "default_instance_type": "ml.m5.xlarge",
+        "default_inference_config": {},
     },
 }
 

--- a/src/autogluon/cloud/model/registry.py
+++ b/src/autogluon/cloud/model/registry.py
@@ -12,6 +12,7 @@ class FoundationModelConfig(TypedDict):
     inference_hyperparameters: Dict[str, Any]  # defaults for deploy() and predict()
     training_hyperparameters: Dict[str, Any]  # defaults for fit()
     default_instance_type: str
+    fine_tunable: bool  # whether .fit() is supported
 
 
 FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
@@ -21,6 +22,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-tiny"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-tiny"},
         "default_instance_type": "ml.g5.xlarge",
+        "fine_tunable": False,
     },
     "chronos-bolt-small": {
         "task": "forecasting",
@@ -28,6 +30,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-small"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-small"},
         "default_instance_type": "ml.g5.xlarge",
+        "fine_tunable": False,
     },
     "chronos-bolt-base": {
         "task": "forecasting",
@@ -35,6 +38,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-base"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-base"},
         "default_instance_type": "ml.g5.xlarge",
+        "fine_tunable": False,
     },
     "chronos-2": {
         "task": "forecasting",
@@ -42,6 +46,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "inference_hyperparameters": {"model_path": "amazon/chronos-2"},
         "training_hyperparameters": {"model_path": "amazon/chronos-2", "fine_tune": True},
         "default_instance_type": "ml.g5.xlarge",
+        "fine_tunable": True,
     },
     # TODO: Replace dummy configs with real values
     "mitra-classification": {
@@ -50,6 +55,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "inference_hyperparameters": {"model_path": "TODO"},
         "training_hyperparameters": {"model_path": "TODO"},
         "default_instance_type": "ml.g5.xlarge",
+        "fine_tunable": False,
     },
     "mitra-regression": {
         "task": "regression",
@@ -57,6 +63,7 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "inference_hyperparameters": {"model_path": "TODO"},
         "training_hyperparameters": {"model_path": "TODO"},
         "default_instance_type": "ml.g5.xlarge",
+        "fine_tunable": False,
     },
 }
 

--- a/src/autogluon/cloud/model/registry.py
+++ b/src/autogluon/cloud/model/registry.py
@@ -1,0 +1,65 @@
+"""Foundation model registry.
+
+Maps model_id to AG-compatible configuration for deploy / predict.
+"""
+
+from typing import Any, Dict, Literal, TypedDict
+
+
+class FoundationModelConfig(TypedDict):
+    task: Literal["timeseries", "tabular"]
+    model_name: str  # AG model class name (e.g. "Chronos", "Chronos2")
+    model_config: Dict[str, Any]  # passed to the AG model (e.g. {"model_path": "..."})
+    default_instance_type: str
+    default_inference_config: Dict[str, Any]  # default prediction kwargs
+
+
+FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
+    "chronos-bolt-tiny": {
+        "task": "timeseries",
+        "model_name": "Chronos",
+        "model_config": {"model_path": "amazon/chronos-bolt-tiny"},
+        "default_instance_type": "ml.g5.xlarge",
+        "default_inference_config": {
+            "prediction_length": 64,
+            "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+        },
+    },
+    "chronos-bolt-small": {
+        "task": "timeseries",
+        "model_name": "Chronos",
+        "model_config": {"model_path": "amazon/chronos-bolt-small"},
+        "default_instance_type": "ml.g5.xlarge",
+        "default_inference_config": {
+            "prediction_length": 64,
+            "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+        },
+    },
+    "chronos-bolt-base": {
+        "task": "timeseries",
+        "model_name": "Chronos",
+        "model_config": {"model_path": "amazon/chronos-bolt-base"},
+        "default_instance_type": "ml.g5.xlarge",
+        "default_inference_config": {
+            "prediction_length": 64,
+            "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+        },
+    },
+    "chronos-2": {
+        "task": "timeseries",
+        "model_name": "Chronos2",
+        "model_config": {"model_path": "amazon/chronos-2"},
+        "default_instance_type": "ml.g5.xlarge",
+        "default_inference_config": {
+            "prediction_length": 64,
+            "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+        },
+    },
+}
+
+
+def get_model_config(model_id: str) -> FoundationModelConfig:
+    if model_id not in FOUNDATION_MODEL_REGISTRY:
+        available = list(FOUNDATION_MODEL_REGISTRY.keys())
+        raise ValueError(f"Unknown model_id '{model_id}'. Available models: {available}")
+    return FOUNDATION_MODEL_REGISTRY[model_id]

--- a/src/autogluon/cloud/model/registry.py
+++ b/src/autogluon/cloud/model/registry.py
@@ -9,7 +9,8 @@ from typing import Any, Dict, Literal, TypedDict
 class FoundationModelConfig(TypedDict):
     task: Literal["forecasting", "classification", "regression"]
     model_name: str  # AG model class name (e.g. "Chronos", "Chronos2", "Mitra")
-    model_config: Dict[str, Any]  # passed to the AG model (e.g. {"model_path": "..."})
+    inference_hyperparameters: Dict[str, Any]  # defaults for deploy() and predict()
+    training_hyperparameters: Dict[str, Any]  # defaults for fit()
     default_instance_type: str
 
 
@@ -17,37 +18,43 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
     "chronos-bolt-tiny": {
         "task": "forecasting",
         "model_name": "Chronos",
-        "model_config": {"model_path": "amazon/chronos-bolt-tiny"},
+        "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-tiny"},
+        "training_hyperparameters": {"model_path": "amazon/chronos-bolt-tiny"},
         "default_instance_type": "ml.g5.xlarge",
     },
     "chronos-bolt-small": {
         "task": "forecasting",
         "model_name": "Chronos",
-        "model_config": {"model_path": "amazon/chronos-bolt-small"},
+        "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-small"},
+        "training_hyperparameters": {"model_path": "amazon/chronos-bolt-small"},
         "default_instance_type": "ml.g5.xlarge",
     },
     "chronos-bolt-base": {
         "task": "forecasting",
         "model_name": "Chronos",
-        "model_config": {"model_path": "amazon/chronos-bolt-base"},
+        "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-base"},
+        "training_hyperparameters": {"model_path": "amazon/chronos-bolt-base"},
         "default_instance_type": "ml.g5.xlarge",
     },
     "chronos-2": {
         "task": "forecasting",
         "model_name": "Chronos2",
-        "model_config": {"model_path": "amazon/chronos-2"},
+        "inference_hyperparameters": {"model_path": "amazon/chronos-2"},
+        "training_hyperparameters": {"model_path": "amazon/chronos-2", "fine_tune": True},
         "default_instance_type": "ml.g5.xlarge",
     },
     "mitra-classification": {
         "task": "classification",
         "model_name": "Mitra",
-        "model_config": {"model_path": "TODO"},
+        "inference_hyperparameters": {"model_path": "TODO"},
+        "training_hyperparameters": {"model_path": "TODO"},
         "default_instance_type": "ml.m5.xlarge",
     },
     "mitra-regression": {
         "task": "regression",
         "model_name": "Mitra",
-        "model_config": {"model_path": "TODO"},
+        "inference_hyperparameters": {"model_path": "TODO"},
+        "training_hyperparameters": {"model_path": "TODO"},
         "default_instance_type": "ml.m5.xlarge",
     },
 }

--- a/src/autogluon/cloud/model/registry.py
+++ b/src/autogluon/cloud/model/registry.py
@@ -11,7 +11,6 @@ class FoundationModelConfig(TypedDict):
     model_name: str  # AG model class name (e.g. "Chronos", "Chronos2", "Mitra")
     model_config: Dict[str, Any]  # passed to the AG model (e.g. {"model_path": "..."})
     default_instance_type: str
-    default_inference_config: Dict[str, Any]  # default prediction kwargs
 
 
 FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
@@ -20,54 +19,36 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos",
         "model_config": {"model_path": "amazon/chronos-bolt-tiny"},
         "default_instance_type": "ml.g5.xlarge",
-        "default_inference_config": {
-            "prediction_length": 64,
-            "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
-        },
     },
     "chronos-bolt-small": {
         "task": "forecasting",
         "model_name": "Chronos",
         "model_config": {"model_path": "amazon/chronos-bolt-small"},
         "default_instance_type": "ml.g5.xlarge",
-        "default_inference_config": {
-            "prediction_length": 64,
-            "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
-        },
     },
     "chronos-bolt-base": {
         "task": "forecasting",
         "model_name": "Chronos",
         "model_config": {"model_path": "amazon/chronos-bolt-base"},
         "default_instance_type": "ml.g5.xlarge",
-        "default_inference_config": {
-            "prediction_length": 64,
-            "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
-        },
     },
     "chronos-2": {
         "task": "forecasting",
         "model_name": "Chronos2",
         "model_config": {"model_path": "amazon/chronos-2"},
         "default_instance_type": "ml.g5.xlarge",
-        "default_inference_config": {
-            "prediction_length": 64,
-            "quantile_levels": [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
-        },
     },
     "mitra-classification": {
         "task": "classification",
         "model_name": "Mitra",
         "model_config": {"model_path": "TODO"},
         "default_instance_type": "ml.m5.xlarge",
-        "default_inference_config": {},
     },
     "mitra-regression": {
         "task": "regression",
         "model_name": "Mitra",
         "model_config": {"model_path": "TODO"},
         "default_instance_type": "ml.m5.xlarge",
-        "default_inference_config": {},
     },
 }
 


### PR DESCRIPTION
Issue #, if available:

- This PR outlines the user-facing API for the new `FoundationModel` class in AutoGluon Cloud. This class allows users to deploy and run inference with pretrained foundation models (Chronos, Mitra, etc.) on AWS.
- How is this different from `sagemaker.jumpstart.JumpStartModel`?
  - DataFrame in / DataFrame out (no manual JSON payload construction)
  - Supports batch prediction and fine-tuning out of the box
  - Model onboarding is much easier for us in the future - any model available in AutoGluon works as soon as we add it to the config
- How is this different from `TimeSeriesCloudPredictor`?
  - No `fit()` required before `deploy()` or `predict()` — foundation models work out of the box
  - Cleaner API: the user does need to provide nested dictionaries of `predictor_init_kwargs` and `predictor_fit_kwargs`
  - The `FoundationModel` class is stateless — no need to worry about the underlying state (attached artifacts, endpoints, etc)

Example usage
```python
# ============================================================
# Time Series — Chronos
# ============================================================
from autogluon.cloud import FoundationModel

model = FoundationModel("chronos-bolt-base", role_arn="arn:aws:iam::123456789:role/SageMakerRole")

# --- Deploy an endpoint ---
endpoint = model.deploy(instance_type="ml.g5.xlarge")
predictions = endpoint.predict(df, prediction_length=24)
endpoint.delete_endpoint()

# --- Batch predict (large dataset, uses SageMaker Training job under the hood) ---
predictions = model.predict(df, prediction_length=24, quantile_levels=[0.1, 0.5, 0.9])

# --- Batch predict (async) ---
job = model.predict(df, prediction_length=24, wait=False)
# ... later ...
predictions = job.result()

# --- Fine-tune, then deploy ---
fine_tuned = model.fit(train_data=df, instance_type="ml.g5.xlarge")
endpoint = fine_tuned.deploy()

# --- Use custom/cached weights (VPC-safe) ---
model = FoundationModel(
    "chronos-bolt-base",
    hyperparameters={"model_path": "s3://my-bucket/cached-weights/"},
)
endpoint = model.deploy()

# --- Override hyperparameters at call time ---
predictions = model.predict(df, prediction_length=24, hyperparameters={"cross_learning": False})

# ============================================================
# Tabular — Mitra / TabICL
# ============================================================
model = FoundationModel("mitra-classification", role_arn="arn:aws:iam::123456789:role/SageMakerRole")

predictions = model.predict(train_data=train_df, test_data=test_df, label="class")
```

To Do:
- [ ] Wiring the user-facing API to the internal backend that actually runs stuff on AWS


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
