### PR TITLE
Implement batch prediction for `TimeSeriesFoundationModel`

### DIFF
--- a/src/autogluon/cloud/backend/backend.py
+++ b/src/autogluon/cloud/backend/backend.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import pickle
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
@@ -29,6 +30,7 @@ class Backend(ABC):
         self._cloud_output_path = cloud_output_path
         self.predictor_type = predictor_type
         self.original_features = None
+        self.endpoint: Optional[Endpoint] = None
 
     @abstractmethod
     def generate_default_permission(self, **kwargs) -> Dict[str, str]:
@@ -91,6 +93,7 @@ class Backend(ABC):
         """
         assert self.predictor_type is not None
         config = self._construct_ag_args(**kwargs)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "wb") as f:
             pickle.dump(config, f)
 

--- a/src/autogluon/cloud/model/__init__.py
+++ b/src/autogluon/cloud/model/__init__.py
@@ -1,3 +1,10 @@
 from .foundation_model import FoundationModel, TabularFoundationModel, TimeSeriesFoundationModel
+from .registry import FoundationModelConfig, get_model_config
 
-__all__ = ["FoundationModel", "TabularFoundationModel", "TimeSeriesFoundationModel"]
+__all__ = [
+    "FoundationModel",
+    "FoundationModelConfig",
+    "TabularFoundationModel",
+    "TimeSeriesFoundationModel",
+    "get_model_config",
+]

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -205,7 +205,6 @@ class TimeSeriesFoundationModel(FoundationModel):
         self,
         target: str = "target",
         prediction_length: int = 1,
-        known_covariates_names: Optional[List[str]] = None,
         quantile_levels: Optional[List[float]] = None,
         **kwargs,
     ) -> Dict[str, Any]:
@@ -214,8 +213,6 @@ class TimeSeriesFoundationModel(FoundationModel):
             "target": target,
             "prediction_length": prediction_length,
         }
-        if known_covariates_names:
-            args["known_covariates_names"] = known_covariates_names
         if quantile_levels is not None:
             args["quantile_levels"] = quantile_levels
         return args
@@ -284,15 +281,9 @@ class TimeSeriesFoundationModel(FoundationModel):
         if instance_type is None:
             instance_type = self._config["predict_instance_type"]
 
-        # Derive known_covariates_names from the DataFrame columns
-        known_covariates_names: Optional[List[str]] = None
-        if known_covariates is not None and isinstance(known_covariates, pd.DataFrame):
-            known_covariates_names = [c for c in known_covariates.columns if c not in (id_column, timestamp_column)]
-
         predictor_init_args = self._build_predictor_init_args(
             target=target,
             prediction_length=prediction_length,
-            known_covariates_names=known_covariates_names,
             quantile_levels=quantile_levels,
         )
 

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import logging
 import tempfile
 from abc import abstractmethod
 from typing import Any, Dict, List, Literal, Optional, Union
@@ -13,8 +12,6 @@ from ..backend.backend_factory import BackendFactory
 from ..backend.constant import SAGEMAKER, TABULAR_SAGEMAKER, TIMESERIES_SAGEMAKER
 from ..endpoint.endpoint import Endpoint
 from .registry import get_model_config
-
-logger = logging.getLogger(__name__)
 
 
 class FoundationModel:
@@ -102,8 +99,38 @@ class FoundationModel:
             "skip_model_selection": True,
         }
 
-    def deploy(self, **kwargs) -> Endpoint:
-        """Deploy model to a real-time endpoint. Not yet implemented."""
+    def deploy(
+        self,
+        instance_type: Optional[str] = None,
+        endpoint_name: Optional[str] = None,
+        hyperparameters: Optional[Dict[str, Any]] = None,
+        wait: bool = True,
+        **backend_kwargs,
+    ) -> Endpoint:
+        """
+        Deploy model to an endpoint.
+
+        Parameters
+        ----------
+        instance_type
+            Instance type for the endpoint.
+            If None, will use the default from the model registry.
+        endpoint_name
+            Custom endpoint name.
+            If None, will auto-generate a unique name.
+        hyperparameters
+            Model hyperparameters for inference. Overrides values passed to the constructor.
+            Available hyperparameters for each model are listed in the AutoGluon documentation.
+        wait
+            Whether to block until the endpoint is ready.
+        **backend_kwargs
+            Backend-specific arguments. Use these to configure serverless, async, or
+            autoscaling (e.g. memory_size_in_mb, max_concurrency, initial_instance_count).
+
+        Returns
+        -------
+        Endpoint
+        """
         raise NotImplementedError
 
     @abstractmethod
@@ -111,12 +138,60 @@ class FoundationModel:
         """Subclasses override with task-specific signature."""
         ...
 
-    def fit(self, train_data: Union[str, pd.DataFrame], **kwargs) -> "FoundationModel":
-        """Fine-tune the model. Not yet implemented."""
+    def fit(
+        self,
+        train_data: Union[str, pd.DataFrame],
+        output_path: Optional[str] = None,
+        instance_type: Optional[str] = None,
+        hyperparameters: Optional[Dict[str, Any]] = None,
+        wait: bool = True,
+        **kwargs,
+    ) -> "FoundationModel":
+        """
+        Fine-tune the model. Returns a new FoundationModel pointing to the fine-tuned artifact.
+
+        Parameters
+        ----------
+        train_data
+            Training data as DataFrame or S3 path.
+        output_path
+            S3 path to store fine-tuned model.
+            If None, will auto-generate under cloud_output_path.
+        instance_type
+            Instance type for the training job.
+            If None, will use the default from the model registry.
+        hyperparameters
+            Model hyperparameters for training. Overrides values passed to the constructor.
+            Available hyperparameters for each model are listed in the AutoGluon documentation.
+        wait
+            If True, block until training completes.
+
+        Returns
+        -------
+        FoundationModel
+            New instance with hyperparameters pointing to the fine-tuned artifact.
+        """
+        if not self._config.get("fine_tunable", False):
+            raise ValueError(f"Model '{self.model_id}' does not support fine-tuning.")
         raise NotImplementedError
 
     def cache_model_artifact(self, s3_path: str) -> str:
-        """Pre-cache model weights to S3. Not yet implemented."""
+        """
+        Pre-cache model weights to S3 (for VPC-deployed endpoints).
+
+        Launches a small job that downloads weights from HuggingFace
+        and uploads them to S3.
+
+        Parameters
+        ----------
+        s3_path
+            S3 path where the model weights should be cached.
+
+        Returns
+        -------
+        str
+            S3 path to the cached artifact.
+        """
         raise NotImplementedError
 
 
@@ -309,12 +384,39 @@ class TabularFoundationModel(FoundationModel):
         test_data: Union[str, pd.DataFrame],
         label: str = "target",
         hyperparameters: Optional[Dict[str, Any]] = None,
+        output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
-        framework_version: str = "latest",
-        custom_image_uri: Optional[str] = None,
         wait: bool = True,
         **backend_kwargs,
     ) -> Optional[pd.DataFrame]:
-        """Run batch prediction returning class probabilities."""
-        # TODO: same implementation as predict() but with predict_proba flag
+        """
+        Run batch prediction returning class probabilities.
+
+        Parameters
+        ----------
+        train_data
+            Labeled few-shot context for the foundation model.
+        test_data
+            Unlabeled data to predict on.
+        label
+            Target column name in train_data.
+        hyperparameters
+            Model hyperparameters for inference. Overrides values passed to the constructor.
+            Available hyperparameters for each model are listed in the AutoGluon documentation.
+        output_path
+            S3 path to store predictions.
+            If None, will auto-generate under cloud_output_path.
+        instance_type
+            Instance type for the prediction job.
+            If None, will use the default from the model registry.
+        wait
+            If True, block and return DataFrame. If False, return the job handle.
+        **backend_kwargs
+            Additional backend-specific arguments (e.g. job_name, custom_image_uri,
+            framework_version, volume_size).
+
+        Returns
+        -------
+        Optional[pd.DataFrame]
+        """
         raise NotImplementedError

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -282,7 +282,7 @@ class TimeSeriesFoundationModel(FoundationModel):
         Optional[pd.DataFrame]
         """
         if instance_type is None:
-            instance_type = self._config["inference_instance_type"]
+            instance_type = self._config["predict_instance_type"]
 
         # Derive known_covariates_names from the DataFrame columns
         known_covariates_names: Optional[List[str]] = None

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -1,16 +1,20 @@
-"""FoundationModel — deploy and predict with pretrained foundation models on AWS."""
+"""FoundationModel — predict with pretrained foundation models on AWS."""
 
 from __future__ import annotations
 
+import logging
+import tempfile
 from abc import abstractmethod
 from typing import Any, Dict, List, Literal, Optional, Union
 
 import pandas as pd
 
-from autogluon.cloud.endpoint.endpoint import Endpoint
-from autogluon.cloud.job.remote_job import RemoteJob
-
+from ..backend.backend_factory import BackendFactory
+from ..backend.constant import SAGEMAKER, TABULAR_SAGEMAKER, TIMESERIES_SAGEMAKER
+from ..endpoint.endpoint import Endpoint
 from .registry import get_model_config
+
+logger = logging.getLogger(__name__)
 
 
 class FoundationModel:
@@ -22,11 +26,12 @@ class FoundationModel:
 
     Examples
     --------
-    >>> model = FoundationModel("chronos-bolt-base", role_arn="arn:...", hyperparameters={"model_path": "s3://cached/"})
-    >>> endpoint = model.deploy()
-    >>> predictions = endpoint.predict(data)
-    >>> endpoint.delete_endpoint()
+    >>> model = FoundationModel("chronos-bolt-base")
+    >>> predictions = model.predict(data, prediction_length=12)
     """
+
+    _backend_map: Dict[str, str] = {}
+    _predictor_type: str
 
     def __new__(cls, model_id: str, **kwargs) -> "FoundationModel":
         if cls is not FoundationModel:
@@ -43,129 +48,102 @@ class FoundationModel:
         self,
         model_id: str,
         backend: Literal["sagemaker"] = "sagemaker",
-        role_arn: Optional[str] = None,
-        region: Optional[str] = None,
-        s3_output_path: Optional[str] = None,
+        cloud_output_path: Optional[str] = None,
         hyperparameters: Optional[Dict[str, Any]] = None,
     ):
         self.model_id = model_id
-        self.role_arn = role_arn
-        self.region = region
-        self.s3_output_path = s3_output_path
+        self.cloud_output_path = cloud_output_path
         self._config = get_model_config(model_id)
         self._hyperparameter_overrides = hyperparameters or {}
-        # TODO: instantiate backend via BackendFactory
-        self._backend_type = backend
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="ag_fm_")
+
+        backend_name = self._backend_map.get(backend)
+        if backend_name is None:
+            raise ValueError(
+                f"Backend '{backend}' is not supported for {self.__class__.__name__}. "
+                f"Available: {list(self._backend_map.keys())}"
+            )
+        self._backend = BackendFactory.get_backend(
+            backend=backend_name,
+            local_output_path=self._tmpdir.name,
+            cloud_output_path=cloud_output_path,
+            predictor_type=self._predictor_type,
+        )
 
     def _get_hyperparameters(
         self, context: Literal["inference", "training"], overrides: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
+        """Merge registry defaults → constructor overrides → call-site overrides."""
         config_key = "inference_hyperparameters" if context == "inference" else "training_hyperparameters"
         return self._config.get(config_key, {}) | self._hyperparameter_overrides | (overrides or {})
 
-    def deploy(
-        self,
-        instance_type: Optional[str] = None,
-        endpoint_name: Optional[str] = None,
-        hyperparameters: Optional[Dict[str, Any]] = None,
-        wait: bool = True,
-        **backend_kwargs,
-    ) -> Endpoint:
-        """
-        Deploy model to an endpoint.
+    @abstractmethod
+    def _build_predictor_init_args(self, **user_kwargs) -> Dict[str, Any]:
+        """Build predictor_init_args dict from user-provided kwargs.
 
-        Parameters
-        ----------
-        instance_type
-            Instance type for the endpoint.
-            If None, will use the default from the model registry.
-        endpoint_name
-            Custom endpoint name.
-            If None, will auto-generate a unique name.
-        hyperparameters
-            Model hyperparameters for inference. Overrides values passed to the constructor.
-            Available hyperparameters for each model are listed in the AutoGluon documentation.
-        wait
-            Whether to block until the endpoint is ready.
-        **backend_kwargs
-            Backend-specific arguments. Use these to configure serverless, async, or
-            autoscaling (e.g. memory_size_in_mb, max_concurrency, initial_instance_count).
-
-        Returns
-        -------
-        Endpoint
+        Subclasses override to map their public API kwargs (e.g., prediction_length,
+        target, known_covariates_names) to the dict that TimeSeriesPredictor/TabularPredictor expects.
         """
+        ...
+
+    def _build_predictor_fit_args(
+        self, train_data, hyperparameters: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Build predictor_fit_args dict.
+
+        Wraps the model hyperparameters into the AG hyperparameters format:
+            {"ModelName": {"model_path": "...", ...}}
+        """
+        model_name = self._config["model_name"]
+        merged_hp = self._get_hyperparameters("inference", hyperparameters)
+        return {
+            "train_data": train_data,
+            "hyperparameters": {model_name: merged_hp},
+            "skip_model_selection": True,
+        }
+
+    def deploy(self, **kwargs) -> Endpoint:
+        """Deploy model to a real-time endpoint. Not yet implemented."""
         raise NotImplementedError
 
     @abstractmethod
-    def predict(self, data: Union[str, pd.DataFrame], wait: bool = True, **kwargs) -> Union[pd.DataFrame, RemoteJob]:
-        """Subclasses override with task-specific signature.
-
-        When wait=False, returns a RemoteJob handle. Use job.get_job_status() to poll
-        and job.get_output_path() to get the S3 path to predictions once complete.
-        """
-        # TODO: consider adding a .result() method to RemoteJob that downloads + parses output
+    def predict(self, data: Union[str, pd.DataFrame], wait: bool = True, **kwargs) -> Optional[pd.DataFrame]:
+        """Subclasses override with task-specific signature."""
         ...
 
-    def fit(
-        self,
-        train_data: Union[str, pd.DataFrame],
-        output_path: Optional[str] = None,
-        instance_type: Optional[str] = None,
-        hyperparameters: Optional[Dict[str, Any]] = None,
-        wait: bool = True,
-        **kwargs,
-    ) -> "FoundationModel":
-        """
-        Fine-tune the model. Returns a new FoundationModel pointing to the fine-tuned artifact.
-
-        Parameters
-        ----------
-        train_data
-            Training data as DataFrame or S3 path.
-        output_path
-            S3 path to store fine-tuned model.
-            If None, will auto-generate under s3_output_path.
-        instance_type
-            Instance type for the training job.
-            If None, will use the default from the model registry.
-        hyperparameters
-            Model hyperparameters for training. Overrides values passed to the constructor.
-            Available hyperparameters for each model are listed in the AutoGluon documentation.
-        wait
-            If True, block until training completes.
-
-        Returns
-        -------
-        FoundationModel
-            New instance with hyperparameters pointing to the fine-tuned artifact.
-        """
-        if not self._config.get("fine_tunable", False):
-            raise ValueError(f"Model '{self.model_id}' does not support fine-tuning.")
+    def fit(self, train_data: Union[str, pd.DataFrame], **kwargs) -> "FoundationModel":
+        """Fine-tune the model. Not yet implemented."""
         raise NotImplementedError
 
     def cache_model_artifact(self, s3_path: str) -> str:
-        """
-        Pre-cache model weights to S3 (for VPC-deployed endpoints).
-
-        Launches a small job that downloads weights from HuggingFace
-        and uploads them to S3.
-
-        Parameters
-        ----------
-        s3_path
-            S3 path where the model weights should be cached.
-
-        Returns
-        -------
-        str
-            S3 path to the cached artifact.
-        """
+        """Pre-cache model weights to S3. Not yet implemented."""
         raise NotImplementedError
 
 
 class TimeSeriesFoundationModel(FoundationModel):
     """Foundation model for time series forecasting (Chronos, etc.)."""
+
+    _backend_map = {SAGEMAKER: TIMESERIES_SAGEMAKER}
+    _predictor_type = "timeseries"
+
+    def _build_predictor_init_args(
+        self,
+        target: str = "target",
+        prediction_length: int = 1,
+        known_covariates_names: Optional[List[str]] = None,
+        quantile_levels: Optional[List[float]] = None,
+        **kwargs,
+    ) -> Dict[str, Any]:
+        """Map user kwargs to TimeSeriesPredictor init args."""
+        args: Dict[str, Any] = {
+            "target": target,
+            "prediction_length": prediction_length,
+        }
+        if known_covariates_names:
+            args["known_covariates_names"] = known_covariates_names
+        if quantile_levels is not None:
+            args["quantile_levels"] = quantile_levels
+        return args
 
     def predict(
         self,
@@ -178,13 +156,17 @@ class TimeSeriesFoundationModel(FoundationModel):
         prediction_length: int = 1,
         quantile_levels: Optional[List[float]] = None,
         hyperparameters: Optional[Dict[str, Any]] = None,
-        output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
+        framework_version: str = "latest",
+        custom_image_uri: Optional[str] = None,
         wait: bool = True,
         **backend_kwargs,
-    ) -> Union[pd.DataFrame, RemoteJob]:
+    ) -> Optional[pd.DataFrame]:
         """
-        Run batch prediction for time series.
+        Run batch prediction for time series via a SageMaker training job (fit_predict pattern).
+
+        Launches a job that loads the foundation model, runs .fit() + .predict() in one shot,
+        and saves predictions to the job output.
 
         Parameters
         ----------
@@ -198,6 +180,8 @@ class TimeSeriesFoundationModel(FoundationModel):
             Name of the timestamp column.
         known_covariates
             Future values of known covariates (DataFrame or S3 path).
+            Covariate column names are inferred from the DataFrame columns
+            (excluding id_column and timestamp_column).
         static_features
             Metadata attributes of individual items (DataFrame or S3 path).
         prediction_length
@@ -206,28 +190,72 @@ class TimeSeriesFoundationModel(FoundationModel):
             Quantiles to predict.
         hyperparameters
             Model hyperparameters for inference. Overrides values passed to the constructor.
-            Available hyperparameters for each model are listed in the AutoGluon documentation.
-        output_path
-            S3 path to store predictions.
-            If None, will auto-generate under s3_output_path.
         instance_type
-            Instance type for the prediction job.
-            If None, will use the default from the model registry.
+            Instance type for the prediction job. If None, uses registry default.
+        framework_version
+            Container framework version.
+        custom_image_uri
+            Custom Docker image URI for the container.
         wait
             If True, block and return DataFrame. If False, return the job handle.
         **backend_kwargs
-            Additional backend-specific arguments (e.g. job_name, custom_image_uri,
-            framework_version, volume_size).
+            Additional backend-specific arguments (e.g., job_name, volume_size,
+            autogluon_sagemaker_estimator_kwargs).
 
         Returns
         -------
-        Union[pd.DataFrame, RemoteJob]
+        Optional[pd.DataFrame]
         """
-        raise NotImplementedError
+        if instance_type is None:
+            instance_type = self._config["inference_instance_type"]
+
+        # Derive known_covariates_names from the DataFrame columns
+        known_covariates_names: Optional[List[str]] = None
+        if known_covariates is not None and isinstance(known_covariates, pd.DataFrame):
+            known_covariates_names = [c for c in known_covariates.columns if c not in (id_column, timestamp_column)]
+
+        predictor_init_args = self._build_predictor_init_args(
+            target=target,
+            prediction_length=prediction_length,
+            known_covariates_names=known_covariates_names,
+            quantile_levels=quantile_levels,
+        )
+
+        predictor_fit_args = self._build_predictor_fit_args(data, hyperparameters)
+
+        if known_covariates is not None:
+            predictor_fit_args["known_covariates"] = known_covariates
+
+        self._backend.fit(
+            predictor_init_args=predictor_init_args,
+            predictor_fit_args=predictor_fit_args,
+            id_column=id_column,
+            timestamp_column=timestamp_column,
+            static_features=static_features,
+            framework_version=framework_version,
+            instance_type=instance_type,
+            custom_image_uri=custom_image_uri,
+            wait=wait,
+            predict_after_fit=True,
+            **backend_kwargs,
+        )
+
+        if not wait:
+            # TODO: return a handle that supports polling status and fetching results
+            return None
+
+        return self._backend.get_fit_predict_results()
 
 
 class TabularFoundationModel(FoundationModel):
     """Foundation model for tabular prediction (Mitra, TabICL, etc.)."""
+
+    _backend_map = {SAGEMAKER: TABULAR_SAGEMAKER}
+    _predictor_type = "tabular"
+
+    def _build_predictor_init_args(self, label: str = "target", **kwargs) -> Dict[str, Any]:
+        """Map user kwargs to TabularPredictor init args."""
+        return {"label": label}
 
     def predict(
         self,
@@ -235,13 +263,17 @@ class TabularFoundationModel(FoundationModel):
         test_data: Union[str, pd.DataFrame],
         label: str = "target",
         hyperparameters: Optional[Dict[str, Any]] = None,
-        output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
+        framework_version: str = "latest",
+        custom_image_uri: Optional[str] = None,
         wait: bool = True,
         **backend_kwargs,
-    ) -> Union[pd.DataFrame, RemoteJob]:
+    ) -> Optional[pd.DataFrame]:
         """
         Run batch prediction for tabular tasks.
+
+        For tabular foundation models (e.g., Mitra), train_data provides the few-shot
+        context and test_data contains the rows to predict on.
 
         Parameters
         ----------
@@ -253,23 +285,22 @@ class TabularFoundationModel(FoundationModel):
             Target column name in train_data.
         hyperparameters
             Model hyperparameters for inference. Overrides values passed to the constructor.
-            Available hyperparameters for each model are listed in the AutoGluon documentation.
-        output_path
-            S3 path to store predictions.
-            If None, will auto-generate under s3_output_path.
         instance_type
-            Instance type for the prediction job.
-            If None, will use the default from the model registry.
+            Instance type for the prediction job. If None, uses registry default.
+        framework_version
+            Container framework version.
+        custom_image_uri
+            Custom Docker image URI for the container.
         wait
             If True, block and return DataFrame. If False, return the job handle.
         **backend_kwargs
-            Additional backend-specific arguments (e.g. job_name, custom_image_uri,
-            framework_version, volume_size).
+            Additional backend-specific arguments.
 
         Returns
         -------
-        Union[pd.DataFrame, RemoteJob]
+        Optional[pd.DataFrame]
         """
+        # TODO: requires fit_predict support for TabularCloudPredictor
         raise NotImplementedError
 
     def predict_proba(
@@ -278,39 +309,12 @@ class TabularFoundationModel(FoundationModel):
         test_data: Union[str, pd.DataFrame],
         label: str = "target",
         hyperparameters: Optional[Dict[str, Any]] = None,
-        output_path: Optional[str] = None,
         instance_type: Optional[str] = None,
+        framework_version: str = "latest",
+        custom_image_uri: Optional[str] = None,
         wait: bool = True,
         **backend_kwargs,
-    ) -> Union[pd.DataFrame, RemoteJob]:
-        """
-        Run batch prediction returning class probabilities.
-
-        Parameters
-        ----------
-        train_data
-            Labeled few-shot context for the foundation model.
-        test_data
-            Unlabeled data to predict on.
-        label
-            Target column name in train_data.
-        hyperparameters
-            Model hyperparameters for inference. Overrides values passed to the constructor.
-            Available hyperparameters for each model are listed in the AutoGluon documentation.
-        output_path
-            S3 path to store predictions.
-            If None, will auto-generate under s3_output_path.
-        instance_type
-            Instance type for the prediction job.
-            If None, will use the default from the model registry.
-        wait
-            If True, block and return DataFrame. If False, return the job handle.
-        **backend_kwargs
-            Additional backend-specific arguments (e.g. job_name, custom_image_uri,
-            framework_version, volume_size).
-
-        Returns
-        -------
-        Union[pd.DataFrame, RemoteJob]
-        """
+    ) -> Optional[pd.DataFrame]:
+        """Run batch prediction returning class probabilities."""
+        # TODO: same implementation as predict() but with predict_proba flag
         raise NotImplementedError

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -83,21 +83,12 @@ class FoundationModel:
         """
         ...
 
+    @abstractmethod
     def _build_predictor_fit_args(
         self, train_data, hyperparameters: Optional[Dict[str, Any]] = None
     ) -> Dict[str, Any]:
-        """Build predictor_fit_args dict.
-
-        Wraps the model hyperparameters into the AG hyperparameters format:
-            {"ModelName": {"model_path": "...", ...}}
-        """
-        model_name = self._config["model_name"]
-        merged_hp = self._get_hyperparameters("inference", hyperparameters)
-        return {
-            "train_data": train_data,
-            "hyperparameters": {model_name: merged_hp},
-            "skip_model_selection": True,
-        }
+        """Build predictor_fit_args dict. Subclasses override with task-specific logic."""
+        ...
 
     def deploy(
         self,
@@ -200,6 +191,17 @@ class TimeSeriesFoundationModel(FoundationModel):
 
     _backend_map = {SAGEMAKER: TIMESERIES_SAGEMAKER}
     _predictor_type = "timeseries"
+
+    def _build_predictor_fit_args(
+        self, train_data, hyperparameters: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, Any]:
+        model_name = self._config["model_name"]
+        merged_hp = self._get_hyperparameters("inference", hyperparameters)
+        return {
+            "train_data": train_data,
+            "hyperparameters": {model_name: merged_hp},
+            "skip_model_selection": True,
+        }
 
     def _build_predictor_init_args(
         self,

--- a/src/autogluon/cloud/model/registry.py
+++ b/src/autogluon/cloud/model/registry.py
@@ -11,7 +11,8 @@ class FoundationModelConfig(TypedDict):
     model_name: str  # AG model class name (e.g. "Chronos", "Chronos2", "Mitra")
     inference_hyperparameters: Dict[str, Any]  # defaults for deploy() and predict()
     training_hyperparameters: Dict[str, Any]  # defaults for fit()
-    default_instance_type: str
+    inference_instance_type: str
+    training_instance_type: str
     fine_tunable: bool  # whether .fit() is supported
 
 
@@ -21,7 +22,8 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos",
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-tiny"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-tiny"},
-        "default_instance_type": "ml.g5.xlarge",
+        "inference_instance_type": "ml.g5.xlarge",
+        "training_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
     "chronos-bolt-small": {
@@ -29,7 +31,8 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos",
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-small"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-small"},
-        "default_instance_type": "ml.g5.xlarge",
+        "inference_instance_type": "ml.g5.xlarge",
+        "training_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
     "chronos-bolt-base": {
@@ -37,7 +40,8 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos",
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-base"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-base"},
-        "default_instance_type": "ml.g5.xlarge",
+        "inference_instance_type": "ml.g5.xlarge",
+        "training_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
     "chronos-2": {
@@ -45,7 +49,8 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos2",
         "inference_hyperparameters": {"model_path": "amazon/chronos-2"},
         "training_hyperparameters": {"model_path": "amazon/chronos-2", "fine_tune": True},
-        "default_instance_type": "ml.g5.xlarge",
+        "inference_instance_type": "ml.g5.xlarge",
+        "training_instance_type": "ml.g5.xlarge",
         "fine_tunable": True,
     },
     # TODO: Replace dummy configs with real values
@@ -54,7 +59,8 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Mitra",
         "inference_hyperparameters": {"model_path": "TODO"},
         "training_hyperparameters": {"model_path": "TODO"},
-        "default_instance_type": "ml.g5.xlarge",
+        "inference_instance_type": "ml.g5.xlarge",
+        "training_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
     "mitra-regression": {
@@ -62,7 +68,8 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Mitra",
         "inference_hyperparameters": {"model_path": "TODO"},
         "training_hyperparameters": {"model_path": "TODO"},
-        "default_instance_type": "ml.g5.xlarge",
+        "inference_instance_type": "ml.g5.xlarge",
+        "training_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
 }

--- a/src/autogluon/cloud/model/registry.py
+++ b/src/autogluon/cloud/model/registry.py
@@ -11,8 +11,9 @@ class FoundationModelConfig(TypedDict):
     model_name: str  # AG model class name (e.g. "Chronos", "Chronos2", "Mitra")
     inference_hyperparameters: Dict[str, Any]  # defaults for deploy() and predict()
     training_hyperparameters: Dict[str, Any]  # defaults for fit()
-    inference_instance_type: str
-    training_instance_type: str
+    predict_instance_type: str  # batch predict
+    deploy_instance_type: str  # real-time endpoint
+    fit_instance_type: str  # fine-tuning
     fine_tunable: bool  # whether .fit() is supported
 
 
@@ -22,8 +23,9 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos",
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-tiny"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-tiny"},
-        "inference_instance_type": "ml.g5.xlarge",
-        "training_instance_type": "ml.g5.xlarge",
+        "predict_instance_type": "ml.m5.2xlarge",
+        "deploy_instance_type": "ml.g5.xlarge",
+        "fit_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
     "chronos-bolt-small": {
@@ -31,8 +33,9 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos",
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-small"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-small"},
-        "inference_instance_type": "ml.g5.xlarge",
-        "training_instance_type": "ml.g5.xlarge",
+        "predict_instance_type": "ml.m5.2xlarge",
+        "deploy_instance_type": "ml.g5.xlarge",
+        "fit_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
     "chronos-bolt-base": {
@@ -40,8 +43,9 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos",
         "inference_hyperparameters": {"model_path": "amazon/chronos-bolt-base"},
         "training_hyperparameters": {"model_path": "amazon/chronos-bolt-base"},
-        "inference_instance_type": "ml.g5.xlarge",
-        "training_instance_type": "ml.g5.xlarge",
+        "predict_instance_type": "ml.m5.2xlarge",
+        "deploy_instance_type": "ml.g5.xlarge",
+        "fit_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
     "chronos-2": {
@@ -49,8 +53,9 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Chronos2",
         "inference_hyperparameters": {"model_path": "amazon/chronos-2"},
         "training_hyperparameters": {"model_path": "amazon/chronos-2", "fine_tune": True},
-        "inference_instance_type": "ml.g5.xlarge",
-        "training_instance_type": "ml.g5.xlarge",
+        "predict_instance_type": "ml.m5.2xlarge",
+        "deploy_instance_type": "ml.g5.xlarge",
+        "fit_instance_type": "ml.g5.xlarge",
         "fine_tunable": True,
     },
     # TODO: Replace dummy configs with real values
@@ -59,8 +64,9 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Mitra",
         "inference_hyperparameters": {"model_path": "TODO"},
         "training_hyperparameters": {"model_path": "TODO"},
-        "inference_instance_type": "ml.g5.xlarge",
-        "training_instance_type": "ml.g5.xlarge",
+        "predict_instance_type": "ml.m5.2xlarge",
+        "deploy_instance_type": "ml.g5.xlarge",
+        "fit_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
     "mitra-regression": {
@@ -68,8 +74,9 @@ FOUNDATION_MODEL_REGISTRY: dict[str, FoundationModelConfig] = {
         "model_name": "Mitra",
         "inference_hyperparameters": {"model_path": "TODO"},
         "training_hyperparameters": {"model_path": "TODO"},
-        "inference_instance_type": "ml.g5.xlarge",
-        "training_instance_type": "ml.g5.xlarge",
+        "predict_instance_type": "ml.m5.2xlarge",
+        "deploy_instance_type": "ml.g5.xlarge",
+        "fit_instance_type": "ml.g5.xlarge",
         "fine_tunable": False,
     },
 }

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
@@ -173,6 +173,9 @@ if __name__ == "__main__":
     if args.known_covariates:
         kc_file = get_input_path(args.known_covariates)
         known_covariates_df = load_pd.load(kc_file)
+        if "known_covariates_names" not in predictor_init_args:
+            kc_cols = known_covariates_df.columns.to_list()
+            predictor_init_args["known_covariates_names"] = kc_cols[2:]  # skip id and timestamp columns
 
     predictor = predictor_cls(**predictor_init_args).fit(training_data, tuning_data=tuning_data, **predictor_fit_args)
 

--- a/tests/unittests/timeseries/test_timeseries.py
+++ b/tests/unittests/timeseries/test_timeseries.py
@@ -159,6 +159,7 @@ def test_foundation_model_predict(test_helper, framework_version, retail_sales_d
             timestamp_column=ds["timestamp_column"],
             prediction_length=ds["prediction_length"],
             known_covariates=ds["known_covariates"],
+            instance_type="ml.m5.2xlarge",
         )
 
         assert isinstance(predictions, pd.DataFrame)

--- a/tests/unittests/timeseries/test_timeseries.py
+++ b/tests/unittests/timeseries/test_timeseries.py
@@ -5,6 +5,31 @@ import pandas as pd
 import pytest
 
 from autogluon.cloud import TimeSeriesCloudPredictor
+from autogluon.cloud.model import FoundationModel
+
+
+@pytest.fixture(scope="module")
+def retail_sales_dataset():
+    """Public retail-sales dataset with train data and known covariates."""
+    target = "Sales"
+    id_column = "id"
+    timestamp_column = "timestamp"
+    prediction_length = 13
+    train_df = pd.read_parquet("https://autogluon.s3.amazonaws.com/datasets/timeseries/retail_sales/train.parquet")
+    train_df[timestamp_column] = pd.to_datetime(train_df[timestamp_column])
+    test_df = pd.read_parquet("https://autogluon.s3.amazonaws.com/datasets/timeseries/retail_sales/test.parquet")
+    test_df[timestamp_column] = pd.to_datetime(test_df[timestamp_column])
+    known_covariates_df = test_df.drop(columns=target)
+    known_covariates_names = [c for c in known_covariates_df.columns if c not in (id_column, timestamp_column)]
+    return {
+        "train_data": train_df,
+        "known_covariates": known_covariates_df,
+        "known_covariates_names": known_covariates_names,
+        "target": target,
+        "id_column": id_column,
+        "timestamp_column": timestamp_column,
+        "prediction_length": prediction_length,
+    }
 
 
 def test_timeseries(test_helper, framework_version):
@@ -56,26 +81,6 @@ def test_timeseries(test_helper, framework_version):
         )
 
 
-def _load_retail_sales_with_covariates():
-    """Fetch the public retail-sales fixture and split it into train + future-covariates frames."""
-    target = "Sales"
-    id_column = "id"
-    timestamp_column = "timestamp"
-    prediction_length = 13
-    train_df = pd.read_parquet("https://autogluon.s3.amazonaws.com/datasets/timeseries/retail_sales/train.parquet")
-    train_df[timestamp_column] = pd.to_datetime(train_df[timestamp_column])
-    test_df = pd.read_parquet("https://autogluon.s3.amazonaws.com/datasets/timeseries/retail_sales/test.parquet")
-    test_df[timestamp_column] = pd.to_datetime(test_df[timestamp_column])
-    known_covariates_df = test_df.drop(columns=target)
-    known_covariates_names = [c for c in known_covariates_df.columns if c not in (id_column, timestamp_column)]
-    predictor_init_args = dict(
-        target=target,
-        prediction_length=prediction_length,
-        known_covariates_names=known_covariates_names,
-    )
-    return train_df, known_covariates_df, predictor_init_args, id_column, timestamp_column, prediction_length
-
-
 @pytest.mark.parametrize(
     "model_name, hyperparameters, with_covariates",
     [
@@ -85,18 +90,19 @@ def _load_retail_sales_with_covariates():
         ("chronos2_with_covs", {"Chronos2": {"model_path": "autogluon/chronos-2-small"}}, True),
     ],
 )
-def test_timeseries_fit_predict_chronos(test_helper, framework_version, model_name, hyperparameters, with_covariates):
+def test_timeseries_fit_predict_chronos(
+    test_helper, framework_version, retail_sales_dataset, model_name, hyperparameters, with_covariates
+):
+    ds = retail_sales_dataset
     timestamp = test_helper.get_utc_timestamp_now()
-    train_data, known_covariates, predictor_init_args, id_column, timestamp_column, prediction_length = (
-        _load_retail_sales_with_covariates()
-    )
-    if not with_covariates:
-        known_covariates = None
-        predictor_init_args.pop("known_covariates_names")
+    known_covariates = ds["known_covariates"] if with_covariates else None
+    predictor_init_args = dict(target=ds["target"], prediction_length=ds["prediction_length"])
+    if with_covariates:
+        predictor_init_args["known_covariates_names"] = ds["known_covariates_names"]
 
     with tempfile.TemporaryDirectory() as temp_dir:
         os.chdir(temp_dir)
-        expected_item_ids = sorted(train_data[id_column].unique())
+        expected_item_ids = sorted(ds["train_data"][ds["id_column"]].unique())
 
         training_custom_image_uri = test_helper.get_custom_image_uri(framework_version, type="training", gpu=False)
 
@@ -108,40 +114,56 @@ def test_timeseries_fit_predict_chronos(test_helper, framework_version, model_na
         )
 
         predictions = cloud_predictor.fit_predict(
-            train_data=train_data,
+            train_data=ds["train_data"],
             known_covariates=known_covariates,
             predictor_init_args=predictor_init_args,
             predictor_fit_args=dict(hyperparameters=hyperparameters),
-            id_column=id_column,
-            timestamp_column=timestamp_column,
+            id_column=ds["id_column"],
+            timestamp_column=ds["timestamp_column"],
             framework_version=framework_version,
             custom_image_uri=training_custom_image_uri,
         )
 
-        assert isinstance(predictions, pd.DataFrame), (
-            f"Expected predictions to be a DataFrame, got {type(predictions).__name__}"
-        )
-        # fit_predict returns predictions with AutoGluon's normalized "item_id" / "timestamp" column names,
-        # matching the contract of real-time and batch transform endpoints.
-        assert {"item_id", "timestamp", "mean"} <= set(predictions.columns), (
-            f"predictions is missing required columns; got {sorted(predictions.columns)}"
-        )
-        assert sorted(predictions["item_id"].astype(str).unique()) == sorted(map(str, expected_item_ids)), (
-            f"predictions ids do not match train_data; "
-            f"expected {expected_item_ids}, got {sorted(predictions['item_id'].unique())}"
-        )
+        assert isinstance(predictions, pd.DataFrame)
+        assert {"item_id", "timestamp", "mean"} <= set(predictions.columns)
+        assert sorted(predictions["item_id"].astype(str).unique()) == sorted(map(str, expected_item_ids))
         counts = predictions.groupby("item_id").size()
-        assert (counts == prediction_length).all(), (
-            f"Expected {prediction_length} rows per item, got {counts.to_dict()}"
-        )
-        assert len(predictions) == len(expected_item_ids) * prediction_length, (
-            f"Expected {len(expected_item_ids) * prediction_length} rows total, got {len(predictions)}"
-        )
+        assert (counts == ds["prediction_length"]).all()
+        assert len(predictions) == len(expected_item_ids) * ds["prediction_length"]
 
         info = cloud_predictor.info()
-        assert info["local_output_path"] is not None, "info()['local_output_path'] is unexpectedly None"
-        assert info["cloud_output_path"] is not None, "info()['cloud_output_path'] is unexpectedly None"
-        assert info["fit_job"]["name"] is not None, "info()['fit_job']['name'] is unexpectedly None"
-        assert info["fit_job"]["status"] == "Completed", (
-            f"Expected fit_job status 'Completed', got {info['fit_job']['status']!r}"
+        assert info["local_output_path"] is not None
+        assert info["cloud_output_path"] is not None
+        assert info["fit_job"]["name"] is not None
+        assert info["fit_job"]["status"] == "Completed"
+
+
+def test_foundation_model_predict(test_helper, framework_version, retail_sales_dataset):
+    """Test FoundationModel batch prediction via the fit_predict training job pattern."""
+    ds = retail_sales_dataset
+    timestamp = test_helper.get_utc_timestamp_now()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.chdir(temp_dir)
+        expected_item_ids = sorted(ds["train_data"][ds["id_column"]].unique())
+
+        model = FoundationModel(
+            "chronos-2",
+            cloud_output_path=f"s3://autogluon-cloud-ci/test-fm-predict/{framework_version}/{timestamp}",
         )
+
+        predictions = model.predict(
+            data=ds["train_data"],
+            target=ds["target"],
+            id_column=ds["id_column"],
+            timestamp_column=ds["timestamp_column"],
+            prediction_length=ds["prediction_length"],
+            known_covariates=ds["known_covariates"],
+        )
+
+        assert isinstance(predictions, pd.DataFrame)
+        assert {"item_id", "timestamp", "mean"} <= set(predictions.columns)
+        assert sorted(predictions["item_id"].astype(str).unique()) == sorted(map(str, expected_item_ids))
+        counts = predictions.groupby("item_id").size()
+        assert (counts == ds["prediction_length"]).all()
+        assert len(predictions) == len(expected_item_ids) * ds["prediction_length"]


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Wire `FoundationModel` to the SageMaker backend, instantiating it via `BackendFactory` in `__init__`
- Implement `TimeSeriesFoundationModel.predict()` which uses the existing fit_predict pattern under the hood (launches a training job that loads the FM, runs fit + predict, returns results)
- Update model registry to store separate default instance types for `predict`, `deploy` and `fit`
- Rename `s3_output_path` → `cloud_output_path` for consistency with the rest of the module; remove `role_arn` and `region` since these are not currently exposed anywhere in the public API
- Streamline FM tests: share a `retail_sales_dataset` fixture, run the new FM test
- Update the training script `src/autogluon/cloud/scripts/sagemaker_scripts/train.py` to automatically infer the `known_covariates_names` if `known_covariates` DF was provided

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
