### PR TITLE
add predictions_path to fit_predict for direct S3 output

### DIFF
--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -341,15 +341,7 @@ class SagemakerBackend(Backend):
         if extra_ag_args:
             ag_args.update(extra_ag_args)
         if ag_args.get("predict_after_fit"):
-            predictions_path = (
-                ag_args.get("predictions_path") or f"{self.cloud_output_path}/{job_name}/predictions.csv"
-            )
-            if not is_s3_url(predictions_path):
-                raise ValueError(
-                    f"`predictions_path` must be a full S3 URL like 's3://bucket/key/predictions.csv', "
-                    f"got {predictions_path!r}."
-                )
-            ag_args["predictions_path"] = predictions_path
+            ag_args.setdefault("predictions_path", f"{self.cloud_output_path}/{job_name}/predictions.csv")
         ag_args_path = os.path.join(self.local_output_path, "utils", "ag_args.pkl")
         self.prepare_args(path=ag_args_path, **ag_args)
         inputs = self._upload_fit_artifact(

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -1004,7 +1004,10 @@ class SagemakerBackend(Backend):
             ag_args = pickle.load(f)
         predictions_path = ag_args.get("predictions_path")
         assert predictions_path is not None, "No fit_predict job found. Call `fit_predict()` first."
-        return load_pd.load(predictions_path)
+        bucket, key = s3_path_to_bucket_prefix(predictions_path)
+        with tempfile.TemporaryDirectory(prefix="ag_fit_predict_") as tmpdir:
+            self.sagemaker_session.download_data(path=tmpdir, bucket=bucket, key_prefix=key)
+            return load_pd.load(os.path.join(tmpdir, os.path.basename(key)))
 
     def _construct_ag_args(self, predictor_init_args, predictor_fit_args, leaderboard, **kwargs):
         config = dict(

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -2,6 +2,7 @@ import copy
 import json
 import logging
 import os
+import pickle
 import tarfile
 import tempfile
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -339,6 +340,16 @@ class SagemakerBackend(Backend):
             ag_args["image_column"] = image_column
         if extra_ag_args:
             ag_args.update(extra_ag_args)
+        if ag_args.get("predict_after_fit"):
+            predictions_path = (
+                ag_args.get("predictions_path") or f"{self.cloud_output_path}/{job_name}/predictions.csv"
+            )
+            if not is_s3_url(predictions_path):
+                raise ValueError(
+                    f"`predictions_path` must be a full S3 URL like 's3://bucket/key/predictions.csv', "
+                    f"got {predictions_path!r}."
+                )
+            ag_args["predictions_path"] = predictions_path
         ag_args_path = os.path.join(self.local_output_path, "utils", "ag_args.pkl")
         self.prepare_args(path=ag_args_path, **ag_args)
         inputs = self._upload_fit_artifact(
@@ -995,31 +1006,13 @@ class SagemakerBackend(Backend):
         return results_save_path
 
     def get_fit_predict_results(self) -> pd.DataFrame:
-        """Download and load predictions produced by a completed ``fit_predict`` job.
-
-        The fit_predict flow persists ``predictions.csv`` inside the training job's ``output.tar.gz``. This method
-        downloads the tarball, extracts the CSV, and returns it as a DataFrame.
-        """
-        import tempfile
-
-        job_name = self._fit_job.job_name
-        assert job_name is not None, "No fit job found. Call `fit_predict()` first."
-        output_tarball = self.cloud_output_path + f"/model/{job_name}/output/output.tar.gz"
-        assert is_s3_url(output_tarball), f"Expected an S3 URL, got {output_tarball!r}"
-
-        with tempfile.TemporaryDirectory(prefix="ag_fit_predict_") as tmpdir:
-            bucket, key = s3_path_to_bucket_prefix(output_tarball)
-            self.sagemaker_session.download_data(path=tmpdir, bucket=bucket, key_prefix=key)
-            tarball_local = os.path.join(tmpdir, os.path.basename(key))
-            with tarfile.open(tarball_local) as tf:
-                try:
-                    fp = tf.extractfile("predictions.csv")
-                except KeyError as e:
-                    raise RuntimeError(
-                        f"predictions.csv not found in {tarball_local}. "
-                        "Did the training job run with `predict_after_fit=True`?"
-                    ) from e
-                return pd.read_csv(fp)
+        """Read predictions produced by a completed ``fit_predict`` job from S3."""
+        ag_args_path = os.path.join(self.local_output_path, "utils", "ag_args.pkl")
+        with open(ag_args_path, "rb") as f:
+            ag_args = pickle.load(f)
+        predictions_path = ag_args.get("predictions_path")
+        assert predictions_path is not None, "No fit_predict job found. Call `fit_predict()` first."
+        return load_pd.load(predictions_path)
 
     def _construct_ag_args(self, predictor_init_args, predictor_fit_args, leaderboard, **kwargs):
         config = dict(

--- a/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
@@ -351,11 +351,12 @@ class TimeSeriesCloudPredictor(CloudPredictor):
         Optional[pd.DataFrame]
             Predictions as a DataFrame. Returns ``None`` when ``wait`` is False.
         """
-        if predictions_path is not None and not is_s3_url(predictions_path):
-            raise ValueError(
-                f"`predictions_path` must be a full S3 URL like 's3://bucket/key/predictions.csv', "
-                f"got {predictions_path!r}."
-            )
+        if predictions_path is not None:
+            if not is_s3_url(predictions_path) or not predictions_path.endswith((".csv", ".parquet")):
+                raise ValueError(
+                    f"`predictions_path` must be a full S3 URL ending in '.csv' or '.parquet' "
+                    f"(e.g. 's3://bucket/key/predictions.parquet'), got {predictions_path!r}."
+                )
         if predictor_fit_args is None:
             predictor_fit_args = {}
         else:

--- a/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
@@ -343,7 +343,8 @@ class TimeSeriesCloudPredictor(CloudPredictor):
             S3 URL where predictions will be written by the training container (e.g.
             ``s3://my-bucket/runs/2024-05-01/predictions.csv``). The container's SageMaker execution role must
             have ``s3:PutObject`` permission for this location. Defaults to
-            ``{cloud_output_path}/{job_name}/predictions.csv``.
+            ``{cloud_output_path}/{job_name}/predictions.csv``. Predictions use AutoGluon's canonical column
+            names ``item_id`` and ``timestamp``, regardless of the ``id_column`` / ``timestamp_column`` passed in.
 
         Returns
         -------

--- a/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 import logging
-import os
 from typing import Any, Dict, Optional, Union
 
 import pandas as pd
+
+from autogluon.common.utils.s3_utils import is_s3_url
 
 from ..backend.constant import SAGEMAKER, TIMESERIES_SAGEMAKER
 from .cloud_predictor import CloudPredictor
@@ -300,7 +301,7 @@ class TimeSeriesCloudPredictor(CloudPredictor):
         volume_size: int = 100,
         custom_image_uri: Optional[str] = None,
         wait: bool = True,
-        save_path: Optional[str] = None,
+        predictions_path: Optional[str] = None,
         backend_kwargs: Optional[Dict] = None,
     ) -> Optional[pd.DataFrame]:
         """
@@ -310,8 +311,8 @@ class TimeSeriesCloudPredictor(CloudPredictor):
         a pretrained model. Running fit and predict in the same job avoids the SageMaker startup overhead twice.
 
         Predictions are generated inside the training container against ``train_data`` (the standard time-series
-        forecasting flow where the last ``prediction_length`` steps of each series are forecast), saved to the job's
-        ``output.tar.gz``, then downloaded locally.
+        forecasting flow where the last ``prediction_length`` steps of each series are forecast) and written
+        directly to S3.
 
         Parameters
         ----------
@@ -338,15 +339,22 @@ class TimeSeriesCloudPredictor(CloudPredictor):
         framework_version, job_name, instance_type, instance_count, volume_size, custom_image_uri, wait,
         backend_kwargs:
             Same semantics as ``fit()``.
-        save_path: Optional[str]
-            If set, the predictions are additionally written to ``<save_path>/predictions.csv``. If not set,
-            predictions are only returned in-memory.
+        predictions_path: Optional[str]
+            S3 URL where predictions will be written by the training container (e.g.
+            ``s3://my-bucket/runs/2024-05-01/predictions.csv``). The container's SageMaker execution role must
+            have ``s3:PutObject`` permission for this location. Defaults to
+            ``{cloud_output_path}/{job_name}/predictions.csv``.
 
         Returns
         -------
         Optional[pd.DataFrame]
             Predictions as a DataFrame. Returns ``None`` when ``wait`` is False.
         """
+        if predictions_path is not None and not is_s3_url(predictions_path):
+            raise ValueError(
+                f"`predictions_path` must be a full S3 URL like 's3://bucket/key/predictions.csv', "
+                f"got {predictions_path!r}."
+            )
         if predictor_fit_args is None:
             predictor_fit_args = {}
         else:
@@ -368,7 +376,10 @@ class TimeSeriesCloudPredictor(CloudPredictor):
             backend_kwargs = {}
         else:
             backend_kwargs = dict(backend_kwargs)
-        backend_kwargs["extra_ag_args"] = {"predict_after_fit": True}
+        extra_ag_args = {"predict_after_fit": True}
+        if predictions_path is not None:
+            extra_ag_args["predictions_path"] = predictions_path
+        backend_kwargs["extra_ag_args"] = extra_ag_args
 
         self.fit(
             predictor_init_args=predictor_init_args,
@@ -393,28 +404,15 @@ class TimeSeriesCloudPredictor(CloudPredictor):
             )
             return None
 
-        return self.get_fit_predict_results(save_path=save_path)
+        return self.get_fit_predict_results()
 
-    def get_fit_predict_results(self, save_path: Optional[str] = None) -> pd.DataFrame:
+    def get_fit_predict_results(self) -> pd.DataFrame:
         """
         Retrieve predictions produced by a completed ``fit_predict`` job.
-
-        Parameters
-        ----------
-        save_path: Optional[str], default = None
-            If set, the predictions are additionally written to ``<save_path>/predictions.csv``. The directory is
-            created if it does not exist. Regardless of this flag, the predictions are returned in-memory.
 
         Returns
         -------
         pd.DataFrame
             Predictions for the forecast horizon.
         """
-        predictions = self.backend.get_fit_predict_results()
-        if save_path is not None:
-            save_path = os.path.abspath(os.path.expanduser(save_path))
-            os.makedirs(save_path, exist_ok=True)
-            output_file = os.path.join(save_path, "predictions.csv")
-            predictions.to_csv(output_file, index=False)
-            logger.log(20, f"fit_predict results saved to {output_file}")
-        return predictions
+        return self.backend.get_fit_predict_results()

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
@@ -5,13 +5,13 @@
 import argparse
 import json
 import os
-import pandas as pd
 import shutil
 from pprint import pprint
 
 import pickle
 
 from autogluon.common.loaders import load_pd
+from autogluon.common.savers import save_pd
 from autogluon.tabular import TabularPredictor, TabularDataset
 from autogluon.timeseries import TimeSeriesDataFrame
 
@@ -180,9 +180,8 @@ if __name__ == "__main__":
             )
         print("Running in-job prediction for fit_predict")
         predictions = predictor.predict(training_data, known_covariates=known_covariates)
-        predictions = pd.DataFrame(predictions).reset_index()
-        predictions_path = os.path.join(args.output_data_dir, "predictions.csv")
-        predictions.to_csv(predictions_path, index=False)
+        predictions_path = ag_args["predictions_path"]
+        save_pd.save(path=predictions_path, df=predictions.to_data_frame().reset_index())
         print(f"Saved predictions to {predictions_path}")
 
     print("Saving serving script")

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
@@ -8,10 +8,12 @@ import os
 import shutil
 from pprint import pprint
 
+import boto3
 import pickle
 
 from autogluon.common.loaders import load_pd
 from autogluon.common.savers import save_pd
+from autogluon.common.utils.s3_utils import s3_path_to_bucket_prefix
 from autogluon.tabular import TabularPredictor, TabularDataset
 from autogluon.timeseries import TimeSeriesDataFrame
 
@@ -181,8 +183,12 @@ if __name__ == "__main__":
         print("Running in-job prediction for fit_predict")
         predictions = predictor.predict(training_data, known_covariates=known_covariates)
         predictions_path = ag_args["predictions_path"]
-        save_pd.save(path=predictions_path, df=predictions.to_data_frame().reset_index())
-        print(f"Saved predictions to {predictions_path}")
+        # Save locally then upload via boto3: s3fs/fsspec are not available in the training container.
+        local_path = os.path.join(args.output_data_dir, os.path.basename(predictions_path))
+        save_pd.save(path=local_path, df=predictions.to_data_frame().reset_index())
+        bucket, key = s3_path_to_bucket_prefix(predictions_path)
+        boto3.client("s3").upload_file(local_path, bucket, key)
+        print(f"Uploaded predictions to {predictions_path}")
 
     print("Saving serving script")
     serving_script_saving_path = os.path.join(save_path, "code")

--- a/tests/unittests/timeseries/test_timeseries.py
+++ b/tests/unittests/timeseries/test_timeseries.py
@@ -115,12 +115,20 @@ def test_timeseries(test_helper, framework_version, retail_sales_dataset):
 def test_timeseries_fit_predict_chronos(
     test_helper, framework_version, retail_sales_dataset, model_name, hyperparameters, with_covariates
 ):
+    import boto3
+
     ds = retail_sales_dataset
     timestamp = test_helper.get_utc_timestamp_now()
     known_covariates = ds["known_covariates"] if with_covariates else None
     predictor_init_args = dict(target=ds["target"], prediction_length=ds["prediction_length"])
     if with_covariates:
         predictor_init_args["known_covariates_names"] = ds["known_covariates_names"]
+
+    bucket = "autogluon-cloud-ci"
+    predictions_key = (
+        f"test-timeseries-fit-predict-{model_name}/{framework_version}/{timestamp}/custom_predictions.parquet"
+    )
+    predictions_path = f"s3://{bucket}/{predictions_key}"
 
     with tempfile.TemporaryDirectory() as temp_dir:
         os.chdir(temp_dir)
@@ -130,7 +138,7 @@ def test_timeseries_fit_predict_chronos(
 
         cloud_predictor = TimeSeriesCloudPredictor(
             cloud_output_path=(
-                f"s3://autogluon-cloud-ci/test-timeseries-fit-predict-{model_name}/{framework_version}/{timestamp}"
+                f"s3://{bucket}/test-timeseries-fit-predict-{model_name}/{framework_version}/{timestamp}"
             ),
             local_output_path=f"test_timeseries_fit_predict_{model_name}_cloud_predictor",
         )
@@ -144,9 +152,13 @@ def test_timeseries_fit_predict_chronos(
             timestamp_column=ds["timestamp_column"],
             framework_version=framework_version,
             custom_image_uri=training_custom_image_uri,
+            predictions_path=predictions_path,
         )
 
         _assert_timeseries_predictions(predictions, expected_item_ids, ds["prediction_length"])
+
+        head = boto3.client("s3").head_object(Bucket=bucket, Key=predictions_key)
+        assert head["ContentLength"] > 0, "predictions file on S3 should not be empty"
 
         info = cloud_predictor.info()
         assert info["local_output_path"] is not None


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Currently, fit_predict packages predictions inside the training job's output.tar.gz. To retrieve them, the client must download the tarball, extract predictions.csv, and load it. This PR adds a new optional parameter predictions_s3_path that tells the container to upload predictions directly to a user-specified S3 location, skipping the tarball packaging entirely.

When predictions_s3_path is not set, behavior is unchanged (backwards compatible).

```python
from autogluon.cloud import TimeSeriesCloudPredictor

predictor = TimeSeriesCloudPredictor(
    cloud_output_path="s3://my-bucket/my-run",
)

predictions = predictor.fit_predict(
    train_data=train_df,
    predictor_init_args=dict(target="target", prediction_length=12),
    predictor_fit_args=dict(
        hyperparameters={"Chronos": {"model_path": "bolt_small"}},
    ),
    id_column="item_id",
    timestamp_column="timestamp",
    # NEW: predictions land directly at this S3 path
    predictions_s3_path="s3://my-bucket/my-run/predictions.csv",
)

# predictions is a DataFrame returned in-memory as before.
# The CSV also exists at s3://my-bucket/my-run/predictions.csv.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
