### PR TITLE
Provide execution role directly to the backend

### DIFF
--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -78,19 +78,16 @@ class SagemakerBackend(Backend):
         Parameters
         ----------
         role
-            Explicit SageMaker execution role ARN. This is the role SageMaker assumes when
-            running training/inference jobs (not the caller's identity). If ``None``, falls
-            back to ``~/.autogluon/cloud.yaml`` and then ``sagemaker.get_execution_role()``.
-            See :func:`autogluon.cloud.utils.aws_utils.resolve_execution_role` for details.
+            SageMaker execution role ARN. See
+            :func:`autogluon.cloud.utils.aws_utils.resolve_execution_role` for the resolution order.
         """
         super().initialize(**kwargs)
         try:
             self.role_arn = resolve_execution_role(role, backend_name=SAGEMAKER)
         except ClientError as e:
             logger.warning(
-                "Failed to resolve SageMaker execution role. Pass `role=<arn>` to the predictor/model, "
-                "run `autogluon.cloud.bootstrap()` / `register()` to persist one, "
-                "or run inside a SageMaker Notebook/Studio so `sagemaker.get_execution_role()` succeeds."
+                "Failed to resolve SageMaker execution role. Pass `role=<arn>` to the predictor/model "
+                "or run `autogluon.cloud.bootstrap()` / `register()` to persist one."
             )
             raise e
         self.sagemaker_session = setup_sagemaker_session()

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -24,7 +24,7 @@ from ..utils.ag_sagemaker import (
     AutoGluonRealtimePredictor,
     AutoGluonRepackInferenceModel,
 )
-from ..utils.aws_utils import setup_sagemaker_session
+from ..utils.aws_utils import resolve_execution_role, setup_sagemaker_session
 from ..utils.constants import CLOUD_RESOURCE_PREFIX, VALID_ACCEPT
 from ..utils.dlc_utils import parse_framework_version
 from ..utils.iam import replace_iam_policy_place_holder, replace_trust_relationship_place_holder
@@ -51,11 +51,19 @@ logger = logging.getLogger(__name__)
 class SagemakerBackend(Backend):
     name = SAGEMAKER
 
-    def __init__(self, local_output_path: str, cloud_output_path: str, predictor_type: str, **kwargs) -> None:
+    def __init__(
+        self,
+        local_output_path: str,
+        cloud_output_path: str,
+        predictor_type: str,
+        role: Optional[str] = None,
+        **kwargs,
+    ) -> None:
         self.initialize(
             local_output_path=local_output_path,
             cloud_output_path=cloud_output_path,
             predictor_type=predictor_type,
+            role=role,
             **kwargs,
         )
 
@@ -64,20 +72,25 @@ class SagemakerBackend(Backend):
         """Class used for realtime endpoint"""
         return AutoGluonRealtimePredictor
 
-    def initialize(self, **kwargs) -> None:
-        """Initialize the backend."""
+    def initialize(self, role: Optional[str] = None, **kwargs) -> None:
+        """Initialize the backend.
+
+        Parameters
+        ----------
+        role
+            Explicit SageMaker execution role ARN. This is the role SageMaker assumes when
+            running training/inference jobs (not the caller's identity). If ``None``, falls
+            back to ``~/.autogluon/cloud.yaml`` and then ``sagemaker.get_execution_role()``.
+            See :func:`autogluon.cloud.utils.aws_utils.resolve_execution_role` for details.
+        """
         super().initialize(**kwargs)
         try:
-            self.role_arn = sagemaker.get_execution_role()
+            self.role_arn = resolve_execution_role(role, backend_name=SAGEMAKER)
         except ClientError as e:
             logger.warning(
-                "Failed to get IAM role. Did you configure and authenticate the IAM role?",
-                "For more information, https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-role.html",
-                f"If you do not have a role created yet, \
-                You can use {self.__class__.__name__}.generate_default_permission() to get the required trust relationship and iam policy",
-                "You can then use the generated trust relationship and IAM policy to create an IAM role",
-                "For more information, https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create.html",
-                "IMPORTANT: Please review the generated trust relationship and IAM policy before you create an IAM role with them",
+                "Failed to resolve SageMaker execution role. Pass `role=<arn>` to the predictor/model, "
+                "run `autogluon.cloud.bootstrap()` / `register()` to persist one, "
+                "or run inside a SageMaker Notebook/Studio so `sagemaker.get_execution_role()` succeeds."
             )
             raise e
         self.sagemaker_session = setup_sagemaker_session()

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -48,7 +48,26 @@ class FoundationModel:
         backend: Literal["sagemaker"] = "sagemaker",
         cloud_output_path: Optional[str] = None,
         hyperparameters: Optional[Dict[str, Any]] = None,
+        role: Optional[str] = None,
     ):
+        """
+        Parameters
+        ----------
+        model_id
+            ID of the foundation model from the model registry.
+        backend
+            Cloud backend to use.
+        cloud_output_path
+            S3 path to store intermediate artifacts.
+        hyperparameters
+            Default hyperparameters applied to inference and (when supported) training.
+        role
+            ARN of the SageMaker execution role — the role that SageMaker assumes when running training and
+            inference jobs. This is *not* the caller's identity (which comes from the standard boto3 credential
+            chain); the caller passes the ARN and SageMaker assumes it on the job's behalf. If ``None``, falls back
+            to ``role_arn`` in ``~/.autogluon/cloud.yaml`` (set by :func:`autogluon.cloud.bootstrap` /
+            :func:`autogluon.cloud.register`), and finally to ``sagemaker.get_execution_role()`` (notebook only).
+        """
         self.model_id = model_id
         self.cloud_output_path = cloud_output_path
         self._config = get_model_config(model_id)
@@ -66,6 +85,7 @@ class FoundationModel:
             local_output_path=self._tmpdir.name,
             cloud_output_path=cloud_output_path,
             predictor_type=self._predictor_type,
+            role=role,
         )
 
     def _get_hyperparameters(

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -62,11 +62,9 @@ class FoundationModel:
         hyperparameters
             Default hyperparameters applied to inference and (when supported) training.
         role
-            ARN of the SageMaker execution role — the role that SageMaker assumes when running training and
-            inference jobs. This is *not* the caller's identity (which comes from the standard boto3 credential
-            chain); the caller passes the ARN and SageMaker assumes it on the job's behalf. If ``None``, falls back
-            to ``role_arn`` in ``~/.autogluon/cloud.yaml`` (set by :func:`autogluon.cloud.bootstrap` /
-            :func:`autogluon.cloud.register`), and finally to ``sagemaker.get_execution_role()`` (notebook only).
+            ARN of the SageMaker execution role used to run training and inference jobs. If ``None``, falls back to
+            ``role_arn`` in ``~/.autogluon/cloud.yaml`` (set by :func:`autogluon.cloud.bootstrap` /
+            :func:`autogluon.cloud.register`), and finally to ``sagemaker.get_execution_role()``.
         """
         self.model_id = model_id
         self.cloud_output_path = cloud_output_path

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -36,6 +36,7 @@ class CloudPredictor(ABC):
         local_output_path: Optional[str] = None,
         cloud_output_path: Optional[str] = None,
         backend: str = SAGEMAKER,
+        role: Optional[str] = None,
         verbosity: int = 2,
     ) -> None:
         """
@@ -60,6 +61,12 @@ class CloudPredictor(ABC):
             The backend to use. Valid options are: "sagemaker" and "ray_aws".
             SageMaker backend supports training, deploying and batch inference on AWS SageMaker. Only single instance training is supported.
             RayAWS backend supports distributed training by creating an ephemeral ray cluster on AWS. Deployment and batch inferenc are not supported yet.
+        role: Optional[str], default = None
+            ARN of the SageMaker execution role — the role that SageMaker assumes when running training and
+            inference jobs. This is *not* the caller's identity (which comes from the standard boto3 credential
+            chain); the caller passes the ARN and SageMaker assumes it on the job's behalf. If ``None``, falls back
+            to ``role_arn`` in ``~/.autogluon/cloud.yaml`` (set by :func:`autogluon.cloud.bootstrap` /
+            :func:`autogluon.cloud.register`), and finally to ``sagemaker.get_execution_role()`` (notebook only).
         verbosity : int, default = 2
             Verbosity levels range from 0 to 4 and control how much information is printed.
             Higher levels correspond to more detailed print statements (you can set verbosity = 0 to suppress warnings).
@@ -76,6 +83,7 @@ class CloudPredictor(ABC):
             local_output_path=self.local_output_path,
             cloud_output_path=self.cloud_output_path,
             predictor_type=self.predictor_type,
+            role=role,
         )
 
     @property

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -62,11 +62,9 @@ class CloudPredictor(ABC):
             SageMaker backend supports training, deploying and batch inference on AWS SageMaker. Only single instance training is supported.
             RayAWS backend supports distributed training by creating an ephemeral ray cluster on AWS. Deployment and batch inferenc are not supported yet.
         role: Optional[str], default = None
-            ARN of the SageMaker execution role — the role that SageMaker assumes when running training and
-            inference jobs. This is *not* the caller's identity (which comes from the standard boto3 credential
-            chain); the caller passes the ARN and SageMaker assumes it on the job's behalf. If ``None``, falls back
-            to ``role_arn`` in ``~/.autogluon/cloud.yaml`` (set by :func:`autogluon.cloud.bootstrap` /
-            :func:`autogluon.cloud.register`), and finally to ``sagemaker.get_execution_role()`` (notebook only).
+            ARN of the SageMaker execution role used to run training and inference jobs. If ``None``, falls back to
+            ``role_arn`` in ``~/.autogluon/cloud.yaml`` (set by :func:`autogluon.cloud.bootstrap` /
+            :func:`autogluon.cloud.register`), and finally to ``sagemaker.get_execution_role()``.
         verbosity : int, default = 2
             Verbosity levels range from 0 to 4 and control how much information is printed.
             Higher levels correspond to more detailed print statements (you can set verbosity = 0 to suppress warnings).

--- a/src/autogluon/cloud/utils/aws_utils.py
+++ b/src/autogluon/cloud/utils/aws_utils.py
@@ -1,8 +1,50 @@
+import logging
 from typing import Optional
 
 import boto3
 import sagemaker
 from botocore.config import Config
+
+from ..config import load_config
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_execution_role(role: Optional[str], backend_name: str) -> str:
+    """Resolve the SageMaker execution role ARN — the role that *jobs* run as on AWS.
+
+    This is distinct from the *caller* identity (the AWS principal calling
+    ``sagemaker:Create*``); the caller never assumes this role. SageMaker assumes it
+    on the job's behalf to access S3 inputs/outputs, ECR images, etc.
+
+    Resolution order:
+
+    1. ``role`` argument if provided.
+    2. ``role_arn`` from ``~/.autogluon/cloud.yaml`` under the matching backend slot.
+    3. ``sagemaker.get_execution_role()`` — only succeeds inside a SageMaker
+       Notebook / Studio environment.
+
+    Parameters
+    ----------
+    role
+        Explicit execution role ARN. If given, returned as-is.
+    backend_name
+        Backend key used to look up the persisted config (e.g. ``"sagemaker"``).
+
+    Returns
+    -------
+    str
+        The resolved execution role ARN.
+    """
+    if role:
+        return role
+    config = load_config()
+    if config is not None:
+        entry = config.backends.get(backend_name)
+        if entry is not None and entry.role_arn:
+            logger.log(20, f"Using execution role from ~/.autogluon/cloud.yaml: {entry.role_arn}")
+            return entry.role_arn
+    return sagemaker.get_execution_role()
 
 
 def get_latest_amazon_linux_ami(region="us-east-1", version="al2023"):

--- a/src/autogluon/cloud/utils/aws_utils.py
+++ b/src/autogluon/cloud/utils/aws_utils.py
@@ -11,30 +11,13 @@ logger = logging.getLogger(__name__)
 
 
 def resolve_execution_role(role: Optional[str], backend_name: str) -> str:
-    """Resolve the SageMaker execution role ARN — the role that *jobs* run as on AWS.
-
-    This is distinct from the *caller* identity (the AWS principal calling
-    ``sagemaker:Create*``); the caller never assumes this role. SageMaker assumes it
-    on the job's behalf to access S3 inputs/outputs, ECR images, etc.
+    """Resolve the SageMaker execution role ARN.
 
     Resolution order:
 
     1. ``role`` argument if provided.
     2. ``role_arn`` from ``~/.autogluon/cloud.yaml`` under the matching backend slot.
-    3. ``sagemaker.get_execution_role()`` — only succeeds inside a SageMaker
-       Notebook / Studio environment.
-
-    Parameters
-    ----------
-    role
-        Explicit execution role ARN. If given, returned as-is.
-    backend_name
-        Backend key used to look up the persisted config (e.g. ``"sagemaker"``).
-
-    Returns
-    -------
-    str
-        The resolved execution role ARN.
+    3. ``sagemaker.get_execution_role()``.
     """
     if role:
         return role

--- a/tests/unittests/general/test_aws_utils.py
+++ b/tests/unittests/general/test_aws_utils.py
@@ -1,0 +1,83 @@
+import logging
+from unittest import mock
+
+import pytest
+
+from autogluon.cloud.config import (
+    CONFIG_DIR_ENV,
+    BackendConfig,
+    CloudConfig,
+    save_config,
+)
+from autogluon.cloud.utils.aws_utils import resolve_execution_role
+
+
+@pytest.fixture(autouse=True)
+def isolated_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv(CONFIG_DIR_ENV, str(tmp_path))
+    yield tmp_path
+
+
+def _save_role_in_config(backend_name: str, role_arn: str) -> None:
+    save_config(
+        CloudConfig(
+            backends={
+                backend_name: BackendConfig(
+                    region="us-east-1",
+                    role_arn=role_arn,
+                    bucket="ag-cloud-bucket",
+                    stack_name="ag-cloud",
+                )
+            }
+        )
+    )
+
+
+def test_explicit_role_wins_over_config_and_env():
+    _save_role_in_config("sagemaker", "arn:aws:iam::111111111111:role/from-config")
+    explicit = "arn:aws:iam::222222222222:role/explicit"
+    with mock.patch("autogluon.cloud.utils.aws_utils.sagemaker.get_execution_role") as mock_env:
+        assert resolve_execution_role(explicit, backend_name="sagemaker") == explicit
+        mock_env.assert_not_called()
+
+
+def test_config_role_used_when_no_explicit():
+    config_role = "arn:aws:iam::111111111111:role/from-config"
+    _save_role_in_config("sagemaker", config_role)
+    aws_utils_logger = logging.getLogger("autogluon.cloud.utils.aws_utils")
+    records: list[logging.LogRecord] = []
+    handler = logging.Handler()
+    handler.setLevel(logging.INFO)
+    handler.emit = records.append
+    aws_utils_logger.addHandler(handler)
+    aws_utils_logger.setLevel(logging.INFO)
+    try:
+        with mock.patch("autogluon.cloud.utils.aws_utils.sagemaker.get_execution_role") as mock_env:
+            assert resolve_execution_role(None, backend_name="sagemaker") == config_role
+            mock_env.assert_not_called()
+    finally:
+        aws_utils_logger.removeHandler(handler)
+    assert any(config_role in r.getMessage() for r in records), (
+        f"expected log mentioning {config_role!r}, got {[r.getMessage() for r in records]}"
+    )
+
+
+def test_falls_back_to_env_when_no_config_or_explicit():
+    env_role = "arn:aws:iam::333333333333:role/from-env"
+    with mock.patch(
+        "autogluon.cloud.utils.aws_utils.sagemaker.get_execution_role",
+        return_value=env_role,
+    ) as mock_env:
+        assert resolve_execution_role(None, backend_name="sagemaker") == env_role
+        mock_env.assert_called_once()
+
+
+def test_falls_back_to_env_when_backend_missing_in_config():
+    _save_role_in_config("ray_aws", "arn:aws:iam::111111111111:role/ray")
+    env_role = "arn:aws:iam::333333333333:role/from-env"
+    with mock.patch(
+        "autogluon.cloud.utils.aws_utils.sagemaker.get_execution_role",
+        return_value=env_role,
+    ) as mock_env:
+        assert resolve_execution_role(None, backend_name="sagemaker") == env_role
+        mock_env.assert_called_once()


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- `utils/aws_utils.py`: new resolve_execution_role(role, backend_name) helper with the 3-tier priority (explicit → `~/.autogluon/cloud.yaml` → `sagemaker.get_execution_role()`). Logs at INFO when the config slot is used.
- `backend/sagemaker_backend.py`: accept role kwarg, route through resolver, simplified the warning to point at the new options (role=, bootstrap()/register(), or notebook env). All Sagemaker subclasses (Tabular/Multimodal/TimeSeries) inherit it for free.
- `predictor/cloud_predictor.py` + `predictor/timeseries_cloud_predictor.py`: surface role on `__init__`, forward to the backend factory. Docstring explicitly notes this is the execution role, not caller identity.
- `model/foundation_model.py`: same surface change with the same docstring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
