### PR TITLE
Replace pickle wire format with JSON envelope in SageMaker serializers

### DIFF
--- a/src/autogluon/cloud/backend/timeseries_sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/timeseries_sagemaker_backend.py
@@ -171,7 +171,7 @@ class TimeSeriesSagemakerBackend(SagemakerBackend):
         # known_covariates side channels.
         payload_dir = os.path.join(self.local_output_path, "utils")
         os.makedirs(payload_dir, exist_ok=True)
-        payload_path = os.path.join(payload_dir, "predict_payload.pkl")
+        payload_path = os.path.join(payload_dir, "predict_payload.json")
         with open(payload_path, "wb") as f:
             f.write(AutoGluonSerializer().serialize(wrapper))
         transform_kwargs = kwargs.pop("transform_kwargs", None) or {}

--- a/src/autogluon/cloud/backend/timeseries_sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/timeseries_sagemaker_backend.py
@@ -166,7 +166,7 @@ class TimeSeriesSagemakerBackend(SagemakerBackend):
             static_features=static_features,
             known_covariates=known_covariates,
         )
-        # Pickle the request body to disk and pass the path through. Force content_type / split_type so
+        # Write the serialized request body to disk. Force content_type / split_type so
         # SageMaker sends the whole body in one transform_fn call — preserves static_features /
         # known_covariates side channels.
         payload_dir = os.path.join(self.local_output_path, "utils")

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/multimodal_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/multimodal_serve.py
@@ -67,11 +67,15 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
 
     elif input_content_type == "application/x-autogluon-parquet":
         payload = json.loads(request_body)
+        if payload.get("version") != 1:
+            raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
         data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
         inference_kwargs = payload.get("inference_kwargs") or {}
 
     elif input_content_type == "application/x-autogluon-npy":
         payload = json.loads(request_body)
+        if payload.get("version") != 1:
+            raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
         image_bytearrays = [base64.b85decode(_bytes) for _bytes in payload["data"]]
         inference_kwargs = payload.get("inference_kwargs") or {}
 

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/multimodal_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/multimodal_serve.py
@@ -1,8 +1,8 @@
 # flake8: noqa
 import base64
 import copy
+import json
 import os
-import pickle
 from io import BytesIO, StringIO
 
 import numpy as np
@@ -66,24 +66,14 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
             image_bytearrays.append(im_bytes)
 
     elif input_content_type == "application/x-autogluon-parquet":
-        buf = bytes(request_body)
-        payload = pickle.loads(buf)
-        data = pd.read_parquet(BytesIO(payload["data"]))
-        inference_kwargs = payload["inference_kwargs"]
-        if inference_kwargs is None:
-            inference_kwargs = {}
+        payload = json.loads(request_body)
+        data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
+        inference_kwargs = payload.get("inference_kwargs") or {}
 
     elif input_content_type == "application/x-autogluon-npy":
-        buf = bytes(request_body)
-        payload = pickle.loads(buf)
-        data = np.load(BytesIO(payload["data"]), allow_pickle=True)
-        image_bytearrays = []
-        for _bytes in data:
-            im_bytes = base64.b85decode(_bytes)
-            image_bytearrays.append(im_bytes)
-        inference_kwargs = payload["inference_kwargs"]
-        if inference_kwargs is None:
-            inference_kwargs = {}
+        payload = json.loads(request_body)
+        image_bytearrays = [base64.b85decode(_bytes) for _bytes in payload["data"]]
+        inference_kwargs = payload.get("inference_kwargs") or {}
 
     elif input_content_type == "application/x-image":
         image_bytearrays = []

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
@@ -1,8 +1,8 @@
 # flake8: noqa
 import base64
 import hashlib
+import json
 import os
-import pickle
 from io import BytesIO, StringIO
 
 import pandas as pd
@@ -59,9 +59,8 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         data = _read_with_fallback(lambda b: pd.read_json(b, orient="records", lines=True), buf, column_names)
 
     elif input_content_type == "application/x-autogluon":
-        buf = bytes(request_body)
-        payload = pickle.loads(buf)
-        data = pd.read_parquet(BytesIO(payload["data"]))
+        payload = json.loads(request_body)
+        data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
         inference_kwargs = payload.get("inference_kwargs", {})
         data = _align_columns(data, column_names)
 

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
@@ -60,6 +60,8 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
 
     elif input_content_type == "application/x-autogluon":
         payload = json.loads(request_body)
+        if payload.get("version") != 1:
+            raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
         data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
         inference_kwargs = payload.get("inference_kwargs", {})
         data = _align_columns(data, column_names)

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_fm_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_fm_serve.py
@@ -46,6 +46,8 @@ def model_fn(model_dir):
 def _parse_autogluon_payload(request_body):
     """Parse x-autogluon payload. Returns (data, known_covariates, inference_kwargs)."""
     payload = json.loads(request_body)
+    if payload.get("version") != 1:
+        raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
     inference_kwargs = payload.get("inference_kwargs") or {}
 
     try:

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_fm_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_fm_serve.py
@@ -4,9 +4,9 @@ Config comes from the AG_SERVE_CONFIG env var (set by the backend at deploy time
     {"model_name": "Chronos", "hyperparameters": {"model_path": "amazon/chronos-bolt-base", ...}}
 """
 
+import base64
 import json
 import os
-import pickle
 from io import BytesIO
 
 import numpy as np
@@ -45,7 +45,7 @@ def model_fn(model_dir):
 
 def _parse_autogluon_payload(request_body):
     """Parse x-autogluon payload. Returns (data, known_covariates, inference_kwargs)."""
-    payload = pickle.loads(request_body)
+    payload = json.loads(request_body)
     inference_kwargs = payload.get("inference_kwargs") or {}
 
     try:
@@ -54,10 +54,10 @@ def _parse_autogluon_payload(request_body):
     except KeyError as e:
         raise ValueError(f"`application/x-autogluon` payload must include {e.args[0]!r} in inference_kwargs.") from e
 
-    data = pd.read_parquet(BytesIO(payload["data"]))
+    data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
     static_features = payload.get("static_features")
     if static_features is not None:
-        static_features = pd.read_parquet(BytesIO(static_features))
+        static_features = pd.read_parquet(BytesIO(base64.b64decode(static_features)))
 
     tsdf = TimeSeriesDataFrame.from_data_frame(
         data, id_column=id_column, timestamp_column=timestamp_column, static_features_df=static_features
@@ -66,7 +66,9 @@ def _parse_autogluon_payload(request_body):
     known_covariates = payload.get("known_covariates")
     if known_covariates is not None:
         known_covariates = TimeSeriesDataFrame.from_data_frame(
-            pd.read_parquet(BytesIO(known_covariates)), id_column=id_column, timestamp_column=timestamp_column
+            pd.read_parquet(BytesIO(base64.b64decode(known_covariates))),
+            id_column=id_column,
+            timestamp_column=timestamp_column,
         )
 
     return tsdf, known_covariates, inference_kwargs

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_serve.py
@@ -39,6 +39,8 @@ def model_fn(model_dir):
 def _parse_autogluon_payload(request_body, *, id_column, timestamp_column):
     """Parse x-autogluon payload. Returns (data, known_covariates, inference_kwargs)."""
     payload = json.loads(request_body)
+    if payload.get("version") != 1:
+        raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
     inference_kwargs = payload.get("inference_kwargs") or {}
 
     data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/timeseries_serve.py
@@ -1,7 +1,7 @@
 # flake8: noqa
+import base64
 import json
 import os
-import pickle
 import shutil
 from io import BytesIO, StringIO
 
@@ -38,13 +38,13 @@ def model_fn(model_dir):
 
 def _parse_autogluon_payload(request_body, *, id_column, timestamp_column):
     """Parse x-autogluon payload. Returns (data, known_covariates, inference_kwargs)."""
-    payload = pickle.loads(request_body)
+    payload = json.loads(request_body)
     inference_kwargs = payload.get("inference_kwargs") or {}
 
-    data = pd.read_parquet(BytesIO(payload["data"]))
+    data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
     static_features = payload.get("static_features")
     if static_features is not None:
-        static_features = pd.read_parquet(BytesIO(static_features))
+        static_features = pd.read_parquet(BytesIO(base64.b64decode(static_features)))
 
     tsdf = TimeSeriesDataFrame.from_data_frame(
         data, id_column=id_column, timestamp_column=timestamp_column, static_features_df=static_features
@@ -53,7 +53,9 @@ def _parse_autogluon_payload(request_body, *, id_column, timestamp_column):
     known_covariates = payload.get("known_covariates")
     if known_covariates is not None:
         known_covariates = TimeSeriesDataFrame.from_data_frame(
-            pd.read_parquet(BytesIO(known_covariates)), id_column=id_column, timestamp_column=timestamp_column
+            pd.read_parquet(BytesIO(base64.b64decode(known_covariates))),
+            id_column=id_column,
+            timestamp_column=timestamp_column,
         )
 
     return tsdf, known_covariates, inference_kwargs

--- a/src/autogluon/cloud/utils/serializers.py
+++ b/src/autogluon/cloud/utils/serializers.py
@@ -31,38 +31,6 @@ class AutoGluonSerializationWrapper:
     known_covariates: Optional[pd.DataFrame] = field(default=None)
 
 
-class ParquetSerializer(SimpleBaseSerializer):
-    """Serialize data to a buffer using the .parquet format."""
-
-    def __init__(self, content_type="application/x-parquet"):
-        """Initialize a ``ParquetSerializer`` instance.
-
-        Args:
-            content_type (str): The MIME type to signal to the inference endpoint when sending
-                request data (default: "application/x-parquet").
-        """
-        super(ParquetSerializer, self).__init__(content_type=content_type)
-
-    def serialize(self, data):
-        """Serialize data to a buffer using the .parquet format.
-
-        Args:
-            data (object): Data to be serialized. Can be a Pandas Dataframe,
-                file, or buffer.
-
-        Returns:
-            io.BytesIO: A buffer containing data serialized in the .parquet format.
-        """
-        if isinstance(data, pd.DataFrame):
-            return data.to_parquet()
-
-        # files and buffers. Assumed to hold parquet-formatted data.
-        if hasattr(data, "read"):
-            return data.read()
-
-        raise ValueError(f"{data} format is not supported. Please provide a DataFrame, parquet file, or buffer.")
-
-
 class AutoGluonSerializer(SimpleBaseSerializer):
     """Serialize data to a buffer with data itself and optional AutoGluon inference arguments."""
 

--- a/src/autogluon/cloud/utils/serializers.py
+++ b/src/autogluon/cloud/utils/serializers.py
@@ -7,6 +7,12 @@ import numpy as np
 import pandas as pd
 from sagemaker.serializers import SimpleBaseSerializer
 
+AUTOGLUON_SERDE_VERSION = 1
+
+
+def _dataframe_to_b64(df: pd.DataFrame) -> str:
+    return base64.b64encode(df.to_parquet()).decode("ascii")
+
 
 def _ensure_json_serializable(inference_kwargs: Dict[str, Any]) -> None:
     try:
@@ -68,7 +74,6 @@ class AutoGluonSerializer(SimpleBaseSerializer):
                 request data (default: "application/x-autogluon").
         """
         super(AutoGluonSerializer, self).__init__(content_type=content_type)
-        self.parquet_serializer = ParquetSerializer()
 
     def serialize(self, data: AutoGluonSerializationWrapper):
         """Serialize data to a JSON envelope with base64-encoded parquet payloads.
@@ -83,17 +88,14 @@ class AutoGluonSerializer(SimpleBaseSerializer):
             inference_kwargs = data.inference_kwargs or {}
             _ensure_json_serializable(inference_kwargs)
             package = {
-                "data": base64.b64encode(self.parquet_serializer.serialize(data.data)).decode("ascii"),
+                "version": AUTOGLUON_SERDE_VERSION,
+                "data": _dataframe_to_b64(data.data),
                 "inference_kwargs": inference_kwargs,
             }
             if data.static_features is not None:
-                package["static_features"] = base64.b64encode(
-                    self.parquet_serializer.serialize(data.static_features)
-                ).decode("ascii")
+                package["static_features"] = _dataframe_to_b64(data.static_features)
             if data.known_covariates is not None:
-                package["known_covariates"] = base64.b64encode(
-                    self.parquet_serializer.serialize(data.known_covariates)
-                ).decode("ascii")
+                package["known_covariates"] = _dataframe_to_b64(data.known_covariates)
             return json.dumps(package).encode("utf-8")
 
         raise ValueError(f"{data} format is not supported. Please provide a `AutoGluonSerializationWrapper`.")
@@ -118,7 +120,6 @@ class MultiModalSerializer(SimpleBaseSerializer):
                 `initial_args` of `predict()` call to endpoints.
         """
         super(MultiModalSerializer, self).__init__(content_type=content_type)
-        self.parquet_serializer = ParquetSerializer()
 
     def serialize(self, data):
         """Serialize data to a JSON envelope.
@@ -140,7 +141,8 @@ class MultiModalSerializer(SimpleBaseSerializer):
 
             if isinstance(data.data, pd.DataFrame):
                 package = {
-                    "data": base64.b64encode(self.parquet_serializer.serialize(data.data)).decode("ascii"),
+                    "version": AUTOGLUON_SERDE_VERSION,
+                    "data": _dataframe_to_b64(data.data),
                     "inference_kwargs": inference_kwargs,
                 }
                 return json.dumps(package).encode("utf-8")
@@ -148,6 +150,7 @@ class MultiModalSerializer(SimpleBaseSerializer):
             if isinstance(data.data, np.ndarray):
                 # The array holds base85-encoded image strings produced by read_image_bytes_and_encode.
                 package = {
+                    "version": AUTOGLUON_SERDE_VERSION,
                     "data": data.data.tolist(),
                     "inference_kwargs": inference_kwargs,
                 }

--- a/src/autogluon/cloud/utils/serializers.py
+++ b/src/autogluon/cloud/utils/serializers.py
@@ -25,6 +25,8 @@ def _ensure_json_serializable(inference_kwargs: Dict[str, Any]) -> None:
 
 @dataclass
 class AutoGluonSerializationWrapper:
+    """Container for data, inference kwargs, and optional side inputs to be serialized into a single request payload."""
+
     data: pd.DataFrame
     inference_kwargs: Dict[str, Any]
     static_features: Optional[pd.DataFrame] = field(default=None)
@@ -129,30 +131,3 @@ class MultiModalSerializer(SimpleBaseSerializer):
             )
 
         raise ValueError(f"{data} format is not supported. Please provide a `AutoGluonSerializationWrapper`")
-
-
-class JsonLineSerializer(SimpleBaseSerializer):
-    """Serialize data to a buffer using the .jsonl format."""
-
-    def __init__(self, content_type="application/jsonl"):
-        """Initialize a ``JsonLineSerializer`` instance.
-
-        Args:
-            content_type (str): The MIME type to signal to the inference endpoint when sending
-                request data (default: "application/jsonl").
-        """
-        super(JsonLineSerializer, self).__init__(content_type=content_type)
-
-    def serialize(self, data):
-        """Serialize data to a buffer using the .jsonl format.
-
-        Args:
-            data (pd.DataFrame): Data to be serialized.
-
-        Returns:
-            io.StringIO: A buffer containing data serialized in the .jsonl format.
-        """
-        if isinstance(data, pd.DataFrame):
-            return data.to_json(orient="records", lines=True)
-
-        raise ValueError(f"{data} format is not supported. Please provide a DataFrame.")

--- a/src/autogluon/cloud/utils/serializers.py
+++ b/src/autogluon/cloud/utils/serializers.py
@@ -54,21 +54,21 @@ class AutoGluonSerializer(SimpleBaseSerializer):
         Returns:
             bytes: UTF-8 JSON containing base64-encoded parquet bytes and inference args
         """
-        if isinstance(data, AutoGluonSerializationWrapper):
-            inference_kwargs = data.inference_kwargs or {}
-            _ensure_json_serializable(inference_kwargs)
-            package = {
-                "version": AUTOGLUON_SERDE_VERSION,
-                "data": _dataframe_to_b64(data.data),
-                "inference_kwargs": inference_kwargs,
-            }
-            if data.static_features is not None:
-                package["static_features"] = _dataframe_to_b64(data.static_features)
-            if data.known_covariates is not None:
-                package["known_covariates"] = _dataframe_to_b64(data.known_covariates)
-            return json.dumps(package).encode("utf-8")
+        if not isinstance(data, AutoGluonSerializationWrapper):
+            raise ValueError(f"{data} format is not supported. Please provide a `AutoGluonSerializationWrapper`.")
 
-        raise ValueError(f"{data} format is not supported. Please provide a `AutoGluonSerializationWrapper`.")
+        inference_kwargs = data.inference_kwargs or {}
+        _ensure_json_serializable(inference_kwargs)
+        package = {
+            "version": AUTOGLUON_SERDE_VERSION,
+            "data": _dataframe_to_b64(data.data),
+            "inference_kwargs": inference_kwargs,
+        }
+        if data.static_features is not None:
+            package["static_features"] = _dataframe_to_b64(data.static_features)
+        if data.known_covariates is not None:
+            package["known_covariates"] = _dataframe_to_b64(data.known_covariates)
+        return json.dumps(package).encode("utf-8")
 
 
 class MultiModalSerializer(SimpleBaseSerializer):
@@ -105,29 +105,29 @@ class MultiModalSerializer(SimpleBaseSerializer):
         Returns:
             bytes: UTF-8 JSON containing both data and inference args
         """
-        if isinstance(data, AutoGluonSerializationWrapper):
-            inference_kwargs = data.inference_kwargs or {}
-            _ensure_json_serializable(inference_kwargs)
+        if not isinstance(data, AutoGluonSerializationWrapper):
+            raise ValueError(f"{data} format is not supported. Please provide a `AutoGluonSerializationWrapper`")
 
-            if isinstance(data.data, pd.DataFrame):
-                package = {
-                    "version": AUTOGLUON_SERDE_VERSION,
-                    "data": _dataframe_to_b64(data.data),
-                    "inference_kwargs": inference_kwargs,
-                }
-                return json.dumps(package).encode("utf-8")
+        inference_kwargs = data.inference_kwargs or {}
+        _ensure_json_serializable(inference_kwargs)
 
-            if isinstance(data.data, np.ndarray):
-                # The array holds base85-encoded image strings produced by read_image_bytes_and_encode.
-                package = {
-                    "version": AUTOGLUON_SERDE_VERSION,
-                    "data": data.data.tolist(),
-                    "inference_kwargs": inference_kwargs,
-                }
-                return json.dumps(package).encode("utf-8")
+        if isinstance(data.data, pd.DataFrame):
+            package = {
+                "version": AUTOGLUON_SERDE_VERSION,
+                "data": _dataframe_to_b64(data.data),
+                "inference_kwargs": inference_kwargs,
+            }
+            return json.dumps(package).encode("utf-8")
 
-            raise ValueError(
-                f"{data} format is not supported. Please provide a `DataFrame, or numpy array.` being wrapped by `AutoGluonSerializationWrapper`"
-            )
+        if isinstance(data.data, np.ndarray):
+            package = {
+                "version": AUTOGLUON_SERDE_VERSION,
+                "data": data.data.tolist(),
+                "inference_kwargs": inference_kwargs,
+            }
+            return json.dumps(package).encode("utf-8")
 
-        raise ValueError(f"{data} format is not supported. Please provide a `AutoGluonSerializationWrapper`")
+        raise ValueError(
+            f"{data.data} format is not supported. Please provide a DataFrame or numpy array"
+            " wrapped by `AutoGluonSerializationWrapper`."
+        )

--- a/src/autogluon/cloud/utils/serializers.py
+++ b/src/autogluon/cloud/utils/serializers.py
@@ -1,10 +1,20 @@
-import pickle
+import base64
+import json
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 import numpy as np
 import pandas as pd
-from sagemaker.serializers import NumpySerializer, SimpleBaseSerializer
+from sagemaker.serializers import SimpleBaseSerializer
+
+
+def _ensure_json_serializable(inference_kwargs: Dict[str, Any]) -> None:
+    try:
+        json.dumps(inference_kwargs)
+    except (TypeError, ValueError) as e:
+        raise ValueError(
+            "`inference_kwargs` must be JSON-serializable; got value that cannot be encoded as JSON."
+        ) from e
 
 
 @dataclass
@@ -61,21 +71,30 @@ class AutoGluonSerializer(SimpleBaseSerializer):
         self.parquet_serializer = ParquetSerializer()
 
     def serialize(self, data: AutoGluonSerializationWrapper):
-        """Serialize data to a buffer using the .parquet format.
+        """Serialize data to a JSON envelope with base64-encoded parquet payloads.
 
         Args:
             data (object): Data to be serialized. An AutoGluonSerializationWrapper object
 
         Returns:
-            bytese: Bytes containing both data and inference args
+            bytes: UTF-8 JSON containing base64-encoded parquet bytes and inference args
         """
         if isinstance(data, AutoGluonSerializationWrapper):
-            package = {"data": self.parquet_serializer.serialize(data.data), "inference_kwargs": data.inference_kwargs}
+            inference_kwargs = data.inference_kwargs or {}
+            _ensure_json_serializable(inference_kwargs)
+            package = {
+                "data": base64.b64encode(self.parquet_serializer.serialize(data.data)).decode("ascii"),
+                "inference_kwargs": inference_kwargs,
+            }
             if data.static_features is not None:
-                package["static_features"] = self.parquet_serializer.serialize(data.static_features)
+                package["static_features"] = base64.b64encode(
+                    self.parquet_serializer.serialize(data.static_features)
+                ).decode("ascii")
             if data.known_covariates is not None:
-                package["known_covariates"] = self.parquet_serializer.serialize(data.known_covariates)
-            return pickle.dumps(package)
+                package["known_covariates"] = base64.b64encode(
+                    self.parquet_serializer.serialize(data.known_covariates)
+                ).decode("ascii")
+            return json.dumps(package).encode("utf-8")
 
         raise ValueError(f"{data} format is not supported. Please provide a `AutoGluonSerializationWrapper`.")
 
@@ -100,33 +119,39 @@ class MultiModalSerializer(SimpleBaseSerializer):
         """
         super(MultiModalSerializer, self).__init__(content_type=content_type)
         self.parquet_serializer = ParquetSerializer()
-        self.numpy_serializer = NumpySerializer()
 
     def serialize(self, data):
-        """Serialize data to a buffer using the .parquet format or numpy format.
+        """Serialize data to a JSON envelope.
+
+        For DataFrame inputs, ``data`` is base64-encoded parquet bytes.
+        For numpy/list image inputs, ``data`` is a JSON list of base85-encoded image strings.
 
         Args:
             data (object): Data to be serialized.
                 An AutoGluonSerializationWrapper, which its data can be a Pandas Dataframe,
-                or a numpy array
+                or a numpy array of base85-encoded image strings.
 
         Returns:
-            bytese: Bytes containing both data and inference args
+            bytes: UTF-8 JSON containing both data and inference args
         """
         if isinstance(data, AutoGluonSerializationWrapper):
+            inference_kwargs = data.inference_kwargs or {}
+            _ensure_json_serializable(inference_kwargs)
+
             if isinstance(data.data, pd.DataFrame):
                 package = {
-                    "data": self.parquet_serializer.serialize(data.data),
-                    "inference_kwargs": data.inference_kwargs,
+                    "data": base64.b64encode(self.parquet_serializer.serialize(data.data)).decode("ascii"),
+                    "inference_kwargs": inference_kwargs,
                 }
-                return pickle.dumps(package)
+                return json.dumps(package).encode("utf-8")
 
             if isinstance(data.data, np.ndarray):
+                # The array holds base85-encoded image strings produced by read_image_bytes_and_encode.
                 package = {
-                    "data": self.numpy_serializer.serialize(data.data),
-                    "inference_kwargs": data.inference_kwargs,
+                    "data": data.data.tolist(),
+                    "inference_kwargs": inference_kwargs,
                 }
-                return pickle.dumps(package)
+                return json.dumps(package).encode("utf-8")
 
             raise ValueError(
                 f"{data} format is not supported. Please provide a `DataFrame, or numpy array.` being wrapped by `AutoGluonSerializationWrapper`"

--- a/src/autogluon/cloud/utils/serializers.py
+++ b/src/autogluon/cloud/utils/serializers.py
@@ -72,11 +72,10 @@ class AutoGluonSerializer(SimpleBaseSerializer):
 
 
 class MultiModalSerializer(SimpleBaseSerializer):
-    """
-    Serializer for multi-modal use case.
-    When passed in a dataframe, the serializer will serialize the data to be parquet format.
-    When passed in a numpy array, the serializer will serialize the data to be numpy format.
-    Both allow passing optional inference arguments along with the data
+    """Serializer for multi-modal use case.
+
+    Produces a JSON envelope containing either base64-encoded parquet (for DataFrames) or a
+    JSON list of base85-encoded image strings (for numpy arrays), plus inference kwargs.
     """
 
     def __init__(self, content_type="application/x-autogluon-parquet"):

--- a/tests/unittests/general/test_serializers.py
+++ b/tests/unittests/general/test_serializers.py
@@ -1,0 +1,192 @@
+import base64
+import json
+from io import BytesIO
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from autogluon.cloud.utils.serializers import (
+    AUTOGLUON_SERDE_VERSION,
+    AutoGluonSerializationWrapper,
+    AutoGluonSerializer,
+    MultiModalSerializer,
+)
+
+
+@pytest.fixture
+def sample_df():
+    return pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
+
+
+@pytest.fixture
+def sample_static_features():
+    return pd.DataFrame({"item_id": [0, 1], "category": ["A", "B"]})
+
+
+@pytest.fixture
+def sample_known_covariates():
+    return pd.DataFrame({"item_id": [0, 0, 1, 1], "promo": [1.0, 0.0, 0.0, 1.0]})
+
+
+def _parse_payload(serialized: bytes) -> dict:
+    return json.loads(serialized)
+
+
+def _decode_parquet(b64_str: str) -> pd.DataFrame:
+    return pd.read_parquet(BytesIO(base64.b64decode(b64_str)))
+
+
+class TestAutoGluonSerializer:
+    def test_full_payload(self, sample_df, sample_static_features, sample_known_covariates):
+        wrapper = AutoGluonSerializationWrapper(
+            data=sample_df,
+            inference_kwargs={"prediction_length": 3, "quantile_levels": [0.1, 0.9]},
+            static_features=sample_static_features,
+            known_covariates=sample_known_covariates,
+        )
+        result = AutoGluonSerializer().serialize(wrapper)
+        payload = _parse_payload(result)
+
+        assert payload["version"] == AUTOGLUON_SERDE_VERSION
+        assert payload["inference_kwargs"] == {"prediction_length": 3, "quantile_levels": [0.1, 0.9]}
+        pd.testing.assert_frame_equal(sample_df, _decode_parquet(payload["data"]))
+        pd.testing.assert_frame_equal(sample_static_features, _decode_parquet(payload["static_features"]))
+        pd.testing.assert_frame_equal(sample_known_covariates, _decode_parquet(payload["known_covariates"]))
+
+    def test_minimal_payload(self, sample_df):
+        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={})
+        result = AutoGluonSerializer().serialize(wrapper)
+        payload = _parse_payload(result)
+
+        assert payload["version"] == AUTOGLUON_SERDE_VERSION
+        assert payload["inference_kwargs"] == {}
+        assert "static_features" not in payload
+        assert "known_covariates" not in payload
+        pd.testing.assert_frame_equal(sample_df, _decode_parquet(payload["data"]))
+
+    def test_none_inference_kwargs(self, sample_df):
+        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs=None)
+        result = AutoGluonSerializer().serialize(wrapper)
+        payload = _parse_payload(result)
+
+        assert payload["inference_kwargs"] == {}
+
+    def test_non_serializable_inference_kwargs_raises(self, sample_df):
+        import datetime
+
+        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={"bad": datetime.datetime.now()})
+        with pytest.raises(ValueError, match="JSON-serializable"):
+            AutoGluonSerializer().serialize(wrapper)
+
+
+class TestMultiModalSerializer:
+    def test_dataframe_payload(self, sample_df):
+        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={"temperature": 0.5})
+        result = MultiModalSerializer().serialize(wrapper)
+        payload = _parse_payload(result)
+
+        assert payload["version"] == AUTOGLUON_SERDE_VERSION
+        assert payload["inference_kwargs"] == {"temperature": 0.5}
+        pd.testing.assert_frame_equal(sample_df, _decode_parquet(payload["data"]))
+
+    def test_numpy_image_payload(self):
+        images = np.array(["b85_encoded_img_1", "b85_encoded_img_2"], dtype="object")
+        wrapper = AutoGluonSerializationWrapper(data=images, inference_kwargs={"realtime": True})
+        result = MultiModalSerializer().serialize(wrapper)
+        payload = _parse_payload(result)
+
+        assert payload["version"] == AUTOGLUON_SERDE_VERSION
+        assert payload["data"] == ["b85_encoded_img_1", "b85_encoded_img_2"]
+        assert payload["inference_kwargs"] == {"realtime": True}
+
+    def test_none_inference_kwargs(self, sample_df):
+        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs=None)
+        result = MultiModalSerializer().serialize(wrapper)
+        payload = _parse_payload(result)
+
+        assert payload["inference_kwargs"] == {}
+
+
+class TestServerSideParsing:
+    """Simulate the server-side parsing logic from the serve scripts."""
+
+    def _server_parse_autogluon(self, serialized: bytes):
+        """Mirrors _parse_autogluon_payload in timeseries_serve.py / timeseries_fm_serve.py."""
+        payload = json.loads(serialized)
+        if payload.get("version") != 1:
+            raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
+        inference_kwargs = payload.get("inference_kwargs") or {}
+        data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
+        static_features = payload.get("static_features")
+        if static_features is not None:
+            static_features = pd.read_parquet(BytesIO(base64.b64decode(static_features)))
+        known_covariates = payload.get("known_covariates")
+        if known_covariates is not None:
+            known_covariates = pd.read_parquet(BytesIO(base64.b64decode(known_covariates)))
+        return data, static_features, known_covariates, inference_kwargs
+
+    def _server_parse_multimodal_npy(self, serialized: bytes):
+        """Mirrors the x-autogluon-npy path in multimodal_serve.py."""
+        payload = json.loads(serialized)
+        if payload.get("version") != 1:
+            raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
+        image_bytearrays = [base64.b85decode(_bytes) for _bytes in payload["data"]]
+        inference_kwargs = payload.get("inference_kwargs") or {}
+        return image_bytearrays, inference_kwargs
+
+    def test_round_trip_full(self, sample_df, sample_static_features, sample_known_covariates):
+        wrapper = AutoGluonSerializationWrapper(
+            data=sample_df,
+            inference_kwargs={"target": "b"},
+            static_features=sample_static_features,
+            known_covariates=sample_known_covariates,
+        )
+        serialized = AutoGluonSerializer().serialize(wrapper)
+        data, sf, kc, kwargs = self._server_parse_autogluon(serialized)
+
+        pd.testing.assert_frame_equal(sample_df, data)
+        pd.testing.assert_frame_equal(sample_static_features, sf)
+        pd.testing.assert_frame_equal(sample_known_covariates, kc)
+        assert kwargs == {"target": "b"}
+
+    def test_round_trip_minimal(self, sample_df):
+        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={})
+        serialized = AutoGluonSerializer().serialize(wrapper)
+        data, sf, kc, kwargs = self._server_parse_autogluon(serialized)
+
+        pd.testing.assert_frame_equal(sample_df, data)
+        assert sf is None
+        assert kc is None
+        assert kwargs == {}
+
+    def test_round_trip_multimodal_images(self):
+        raw_images = [b"\x89PNG_fake_image_1", b"\x89PNG_fake_image_2"]
+        b85_images = np.array([base64.b85encode(img).decode("utf-8") for img in raw_images], dtype="object")
+
+        wrapper = AutoGluonSerializationWrapper(data=b85_images, inference_kwargs={"k": 5})
+        serialized = MultiModalSerializer().serialize(wrapper)
+        image_bytearrays, kwargs = self._server_parse_multimodal_npy(serialized)
+
+        assert image_bytearrays == raw_images
+        assert kwargs == {"k": 5}
+
+    def test_wrong_version_raises(self, sample_df):
+        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={})
+        serialized = AutoGluonSerializer().serialize(wrapper)
+        # Tamper with the version
+        payload = json.loads(serialized)
+        payload["version"] = 99
+        tampered = json.dumps(payload).encode("utf-8")
+
+        with pytest.raises(ValueError, match="Unsupported x-autogluon payload version: 99"):
+            self._server_parse_autogluon(tampered)
+
+    def test_missing_version_raises(self, sample_df):
+        payload = json.dumps({"data": "irrelevant", "inference_kwargs": {}}).encode("utf-8")
+        with pytest.raises(ValueError, match="Unsupported x-autogluon payload version: None"):
+            self._server_parse_autogluon(payload)
+
+    def test_malformed_json_raises(self):
+        with pytest.raises(json.JSONDecodeError):
+            self._server_parse_autogluon(b"not json at all")

--- a/tests/unittests/general/test_serializers.py
+++ b/tests/unittests/general/test_serializers.py
@@ -107,6 +107,11 @@ class TestMultiModalSerializer:
 
         assert payload["inference_kwargs"] == {}
 
+    def test_unsupported_data_type_raises(self):
+        wrapper = AutoGluonSerializationWrapper(data=["not", "a", "df", "or", "array"], inference_kwargs={})
+        with pytest.raises(ValueError, match="format is not supported"):
+            MultiModalSerializer().serialize(wrapper)
+
 
 class TestServerSideParsing:
     """Simulate the server-side parsing logic from the serve scripts."""

--- a/tests/unittests/general/test_serializers.py
+++ b/tests/unittests/general/test_serializers.py
@@ -1,4 +1,5 @@
 import base64
+import datetime
 import json
 from io import BytesIO
 
@@ -15,183 +16,174 @@ from autogluon.cloud.utils.serializers import (
 
 
 @pytest.fixture
-def sample_df():
+def df():
     return pd.DataFrame({"a": [1, 2, 3], "b": ["x", "y", "z"]})
 
 
 @pytest.fixture
-def sample_static_features():
+def static_features():
     return pd.DataFrame({"item_id": [0, 1], "category": ["A", "B"]})
 
 
 @pytest.fixture
-def sample_known_covariates():
+def known_covariates():
     return pd.DataFrame({"item_id": [0, 0, 1, 1], "promo": [1.0, 0.0, 0.0, 1.0]})
-
-
-def _parse_payload(serialized: bytes) -> dict:
-    return json.loads(serialized)
 
 
 def _decode_parquet(b64_str: str) -> pd.DataFrame:
     return pd.read_parquet(BytesIO(base64.b64decode(b64_str)))
 
 
-class TestAutoGluonSerializer:
-    def test_full_payload(self, sample_df, sample_static_features, sample_known_covariates):
-        wrapper = AutoGluonSerializationWrapper(
-            data=sample_df,
-            inference_kwargs={"prediction_length": 3, "quantile_levels": [0.1, 0.9]},
-            static_features=sample_static_features,
-            known_covariates=sample_known_covariates,
-        )
-        result = AutoGluonSerializer().serialize(wrapper)
-        payload = _parse_payload(result)
-
-        assert payload["version"] == AUTOGLUON_SERDE_VERSION
-        assert payload["inference_kwargs"] == {"prediction_length": 3, "quantile_levels": [0.1, 0.9]}
-        pd.testing.assert_frame_equal(sample_df, _decode_parquet(payload["data"]))
-        pd.testing.assert_frame_equal(sample_static_features, _decode_parquet(payload["static_features"]))
-        pd.testing.assert_frame_equal(sample_known_covariates, _decode_parquet(payload["known_covariates"]))
-
-    def test_minimal_payload(self, sample_df):
-        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={})
-        result = AutoGluonSerializer().serialize(wrapper)
-        payload = _parse_payload(result)
-
-        assert payload["version"] == AUTOGLUON_SERDE_VERSION
-        assert payload["inference_kwargs"] == {}
-        assert "static_features" not in payload
-        assert "known_covariates" not in payload
-        pd.testing.assert_frame_equal(sample_df, _decode_parquet(payload["data"]))
-
-    def test_none_inference_kwargs(self, sample_df):
-        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs=None)
-        result = AutoGluonSerializer().serialize(wrapper)
-        payload = _parse_payload(result)
-
-        assert payload["inference_kwargs"] == {}
-
-    def test_non_serializable_inference_kwargs_raises(self, sample_df):
-        import datetime
-
-        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={"bad": datetime.datetime.now()})
-        with pytest.raises(ValueError, match="JSON-serializable"):
-            AutoGluonSerializer().serialize(wrapper)
+def _server_parse_autogluon(serialized):
+    """Mirrors _parse_autogluon_payload in timeseries_serve.py / timeseries_fm_serve.py."""
+    payload = json.loads(serialized)
+    if payload.get("version") != 1:
+        raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
+    inference_kwargs = payload.get("inference_kwargs") or {}
+    data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
+    static_features = payload.get("static_features")
+    if static_features is not None:
+        static_features = pd.read_parquet(BytesIO(base64.b64decode(static_features)))
+    known_covariates = payload.get("known_covariates")
+    if known_covariates is not None:
+        known_covariates = pd.read_parquet(BytesIO(base64.b64decode(known_covariates)))
+    return data, static_features, known_covariates, inference_kwargs
 
 
-class TestMultiModalSerializer:
-    def test_dataframe_payload(self, sample_df):
-        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={"temperature": 0.5})
-        result = MultiModalSerializer().serialize(wrapper)
-        payload = _parse_payload(result)
-
-        assert payload["version"] == AUTOGLUON_SERDE_VERSION
-        assert payload["inference_kwargs"] == {"temperature": 0.5}
-        pd.testing.assert_frame_equal(sample_df, _decode_parquet(payload["data"]))
-
-    def test_numpy_image_payload(self):
-        images = np.array(["b85_encoded_img_1", "b85_encoded_img_2"], dtype="object")
-        wrapper = AutoGluonSerializationWrapper(data=images, inference_kwargs={"realtime": True})
-        result = MultiModalSerializer().serialize(wrapper)
-        payload = _parse_payload(result)
-
-        assert payload["version"] == AUTOGLUON_SERDE_VERSION
-        assert payload["data"] == ["b85_encoded_img_1", "b85_encoded_img_2"]
-        assert payload["inference_kwargs"] == {"realtime": True}
-
-    def test_none_inference_kwargs(self, sample_df):
-        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs=None)
-        result = MultiModalSerializer().serialize(wrapper)
-        payload = _parse_payload(result)
-
-        assert payload["inference_kwargs"] == {}
-
-    def test_unsupported_data_type_raises(self):
-        wrapper = AutoGluonSerializationWrapper(data=["not", "a", "df", "or", "array"], inference_kwargs={})
-        with pytest.raises(ValueError, match="format is not supported"):
-            MultiModalSerializer().serialize(wrapper)
+def _server_parse_multimodal_npy(serialized):
+    """Mirrors the x-autogluon-npy path in multimodal_serve.py."""
+    payload = json.loads(serialized)
+    if payload.get("version") != 1:
+        raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
+    image_bytearrays = [base64.b85decode(_bytes) for _bytes in payload["data"]]
+    inference_kwargs = payload.get("inference_kwargs") or {}
+    return image_bytearrays, inference_kwargs
 
 
-class TestServerSideParsing:
-    """Simulate the server-side parsing logic from the serve scripts."""
+# --- AutoGluonSerializer ---
 
-    def _server_parse_autogluon(self, serialized: bytes):
-        """Mirrors _parse_autogluon_payload in timeseries_serve.py / timeseries_fm_serve.py."""
-        payload = json.loads(serialized)
-        if payload.get("version") != 1:
-            raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
-        inference_kwargs = payload.get("inference_kwargs") or {}
-        data = pd.read_parquet(BytesIO(base64.b64decode(payload["data"])))
-        static_features = payload.get("static_features")
-        if static_features is not None:
-            static_features = pd.read_parquet(BytesIO(base64.b64decode(static_features)))
-        known_covariates = payload.get("known_covariates")
-        if known_covariates is not None:
-            known_covariates = pd.read_parquet(BytesIO(base64.b64decode(known_covariates)))
-        return data, static_features, known_covariates, inference_kwargs
 
-    def _server_parse_multimodal_npy(self, serialized: bytes):
-        """Mirrors the x-autogluon-npy path in multimodal_serve.py."""
-        payload = json.loads(serialized)
-        if payload.get("version") != 1:
-            raise ValueError(f"Unsupported x-autogluon payload version: {payload.get('version')}. Expected 1.")
-        image_bytearrays = [base64.b85decode(_bytes) for _bytes in payload["data"]]
-        inference_kwargs = payload.get("inference_kwargs") or {}
-        return image_bytearrays, inference_kwargs
+def test_when_all_fields_provided_then_payload_contains_version_and_data(df, static_features, known_covariates):
+    wrapper = AutoGluonSerializationWrapper(
+        data=df,
+        inference_kwargs={"prediction_length": 3, "quantile_levels": [0.1, 0.9]},
+        static_features=static_features,
+        known_covariates=known_covariates,
+    )
+    payload = json.loads(AutoGluonSerializer().serialize(wrapper))
 
-    def test_round_trip_full(self, sample_df, sample_static_features, sample_known_covariates):
-        wrapper = AutoGluonSerializationWrapper(
-            data=sample_df,
-            inference_kwargs={"target": "b"},
-            static_features=sample_static_features,
-            known_covariates=sample_known_covariates,
-        )
-        serialized = AutoGluonSerializer().serialize(wrapper)
-        data, sf, kc, kwargs = self._server_parse_autogluon(serialized)
+    assert payload["version"] == AUTOGLUON_SERDE_VERSION
+    assert payload["inference_kwargs"] == {"prediction_length": 3, "quantile_levels": [0.1, 0.9]}
+    pd.testing.assert_frame_equal(df, _decode_parquet(payload["data"]))
+    pd.testing.assert_frame_equal(static_features, _decode_parquet(payload["static_features"]))
+    pd.testing.assert_frame_equal(known_covariates, _decode_parquet(payload["known_covariates"]))
 
-        pd.testing.assert_frame_equal(sample_df, data)
-        pd.testing.assert_frame_equal(sample_static_features, sf)
-        pd.testing.assert_frame_equal(sample_known_covariates, kc)
-        assert kwargs == {"target": "b"}
 
-    def test_round_trip_minimal(self, sample_df):
-        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={})
-        serialized = AutoGluonSerializer().serialize(wrapper)
-        data, sf, kc, kwargs = self._server_parse_autogluon(serialized)
+def test_when_no_optional_fields_then_payload_omits_them(df):
+    wrapper = AutoGluonSerializationWrapper(data=df, inference_kwargs={})
+    payload = json.loads(AutoGluonSerializer().serialize(wrapper))
 
-        pd.testing.assert_frame_equal(sample_df, data)
-        assert sf is None
-        assert kc is None
-        assert kwargs == {}
+    assert "static_features" not in payload
+    assert "known_covariates" not in payload
+    pd.testing.assert_frame_equal(df, _decode_parquet(payload["data"]))
 
-    def test_round_trip_multimodal_images(self):
-        raw_images = [b"\x89PNG_fake_image_1", b"\x89PNG_fake_image_2"]
-        b85_images = np.array([base64.b85encode(img).decode("utf-8") for img in raw_images], dtype="object")
 
-        wrapper = AutoGluonSerializationWrapper(data=b85_images, inference_kwargs={"k": 5})
-        serialized = MultiModalSerializer().serialize(wrapper)
-        image_bytearrays, kwargs = self._server_parse_multimodal_npy(serialized)
+def test_when_inference_kwargs_is_none_then_treated_as_empty(df):
+    wrapper = AutoGluonSerializationWrapper(data=df, inference_kwargs=None)
+    payload = json.loads(AutoGluonSerializer().serialize(wrapper))
+    assert payload["inference_kwargs"] == {}
 
-        assert image_bytearrays == raw_images
-        assert kwargs == {"k": 5}
 
-    def test_wrong_version_raises(self, sample_df):
-        wrapper = AutoGluonSerializationWrapper(data=sample_df, inference_kwargs={})
-        serialized = AutoGluonSerializer().serialize(wrapper)
-        # Tamper with the version
-        payload = json.loads(serialized)
-        payload["version"] = 99
-        tampered = json.dumps(payload).encode("utf-8")
+def test_when_inference_kwargs_not_json_serializable_then_raises(df):
+    wrapper = AutoGluonSerializationWrapper(data=df, inference_kwargs={"bad": datetime.datetime.now()})
+    with pytest.raises(ValueError, match="JSON-serializable"):
+        AutoGluonSerializer().serialize(wrapper)
 
-        with pytest.raises(ValueError, match="Unsupported x-autogluon payload version: 99"):
-            self._server_parse_autogluon(tampered)
 
-    def test_missing_version_raises(self, sample_df):
-        payload = json.dumps({"data": "irrelevant", "inference_kwargs": {}}).encode("utf-8")
-        with pytest.raises(ValueError, match="Unsupported x-autogluon payload version: None"):
-            self._server_parse_autogluon(payload)
+# --- MultiModalSerializer ---
 
-    def test_malformed_json_raises(self):
-        with pytest.raises(json.JSONDecodeError):
-            self._server_parse_autogluon(b"not json at all")
+
+def test_given_dataframe_then_payload_has_base64_parquet(df):
+    wrapper = AutoGluonSerializationWrapper(data=df, inference_kwargs={"temperature": 0.5})
+    payload = json.loads(MultiModalSerializer().serialize(wrapper))
+
+    assert payload["version"] == AUTOGLUON_SERDE_VERSION
+    assert payload["inference_kwargs"] == {"temperature": 0.5}
+    pd.testing.assert_frame_equal(df, _decode_parquet(payload["data"]))
+
+
+def test_given_numpy_images_then_payload_has_json_list():
+    images = np.array(["b85_encoded_img_1", "b85_encoded_img_2"], dtype="object")
+    wrapper = AutoGluonSerializationWrapper(data=images, inference_kwargs={"realtime": True})
+    payload = json.loads(MultiModalSerializer().serialize(wrapper))
+
+    assert payload["version"] == AUTOGLUON_SERDE_VERSION
+    assert payload["data"] == ["b85_encoded_img_1", "b85_encoded_img_2"]
+    assert payload["inference_kwargs"] == {"realtime": True}
+
+
+def test_given_multimodal_none_kwargs_then_treated_as_empty(df):
+    wrapper = AutoGluonSerializationWrapper(data=df, inference_kwargs=None)
+    payload = json.loads(MultiModalSerializer().serialize(wrapper))
+    assert payload["inference_kwargs"] == {}
+
+
+def test_given_unsupported_data_type_then_raises():
+    wrapper = AutoGluonSerializationWrapper(data=["not", "a", "df"], inference_kwargs={})
+    with pytest.raises(ValueError, match="format is not supported"):
+        MultiModalSerializer().serialize(wrapper)
+
+
+# --- Server-side round-trip ---
+
+
+def test_given_full_payload_then_server_recovers_all_fields(df, static_features, known_covariates):
+    wrapper = AutoGluonSerializationWrapper(
+        data=df, inference_kwargs={"target": "b"}, static_features=static_features, known_covariates=known_covariates
+    )
+    data, sf, kc, kwargs = _server_parse_autogluon(AutoGluonSerializer().serialize(wrapper))
+
+    pd.testing.assert_frame_equal(df, data)
+    pd.testing.assert_frame_equal(static_features, sf)
+    pd.testing.assert_frame_equal(known_covariates, kc)
+    assert kwargs == {"target": "b"}
+
+
+def test_given_minimal_payload_then_optionals_are_none(df):
+    wrapper = AutoGluonSerializationWrapper(data=df, inference_kwargs={})
+    data, sf, kc, kwargs = _server_parse_autogluon(AutoGluonSerializer().serialize(wrapper))
+
+    pd.testing.assert_frame_equal(df, data)
+    assert sf is None
+    assert kc is None
+    assert kwargs == {}
+
+
+def test_given_image_payload_then_server_decodes_to_original_bytes():
+    raw_images = [b"\x89PNG_fake_image_1", b"\x89PNG_fake_image_2"]
+    b85_images = np.array([base64.b85encode(img).decode("utf-8") for img in raw_images], dtype="object")
+
+    wrapper = AutoGluonSerializationWrapper(data=b85_images, inference_kwargs={"k": 5})
+    image_bytearrays, kwargs = _server_parse_multimodal_npy(MultiModalSerializer().serialize(wrapper))
+
+    assert image_bytearrays == raw_images
+    assert kwargs == {"k": 5}
+
+
+def test_when_version_wrong_then_server_rejects(df):
+    payload = json.loads(AutoGluonSerializer().serialize(AutoGluonSerializationWrapper(data=df, inference_kwargs={})))
+    payload["version"] = 99
+
+    with pytest.raises(ValueError, match="Unsupported x-autogluon payload version: 99"):
+        _server_parse_autogluon(json.dumps(payload).encode("utf-8"))
+
+
+def test_when_version_missing_then_server_rejects():
+    payload = json.dumps({"data": "irrelevant", "inference_kwargs": {}}).encode("utf-8")
+    with pytest.raises(ValueError, match="Unsupported x-autogluon payload version: None"):
+        _server_parse_autogluon(payload)
+
+
+def test_when_body_not_json_then_server_rejects():
+    with pytest.raises(json.JSONDecodeError):
+        _server_parse_autogluon(b"not json at all")


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Switch `application/x-autogluon*` wire format from pickle to JSON for better security - **breaking change**, old endpoints cannot be used with the new AG-Cloud version
- JSON envelope with base64-encoded parquet for DataFrames, plain JSON list for image byte-strings, and a validated `inference_kwargs` dict
- Add `"version": 1` field to enable clear error messages on future format mismatches
- Remove unused classes `ParquetSerializer` and `JsonLinesSerializer`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
