### PR TITLE
Create endpoint from name + allow Python 3.13

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,7 +4,7 @@ import sys
 sys.path = [".", ".."] + sys.path
 
 project = "AutoGluon-Cloud"
-release = "0.4.2"
+release = "0.5.0"
 copyright = "2023, All authors. Licensed under Apache 2.0."
 author = "AutoGluon contributors"
 

--- a/docs/tutorials/foundation-model-timeseries.md
+++ b/docs/tutorials/foundation-model-timeseries.md
@@ -160,6 +160,21 @@ The endpoint stays active — and billed — until you delete it:
 endpoint.delete_endpoint()
 ```
 
+### Reattaching to an existing endpoint
+
+To send requests to an endpoint that's already running (e.g. from a previous session, or one a
+teammate deployed), build a {py:class}`~autogluon.cloud.TimeSeriesEndpoint` directly from the
+endpoint name:
+
+```python
+from autogluon.cloud import TimeSeriesEndpoint
+
+endpoint = TimeSeriesEndpoint(endpoint_name="my-existing-endpoint")
+```
+
+Pass a configured `boto3.Session` to use a non-default AWS profile or region. The endpoint must
+have been deployed via AutoGluon-Cloud, since the request payload format is AutoGluon-specific.
+
 ## Serverless inference
 
 Serverless endpoints scale to zero between requests, so you only pay for active inference time. They run network-isolated, which means the model weights have to be bundled into a single `model.tar.gz` ahead of time rather than downloaded from HuggingFace at deploy time. Use {py:meth}`~autogluon.cloud.TimeSeriesFoundationModel.cache_model_artifact` to do this once, then deploy with `inference_mode="serverless"`:

--- a/docs/versions.rst
+++ b/docs/versions.rst
@@ -3,11 +3,11 @@ Available Documentation for AutoGluon-Cloud
 
 Web-based documentation is available for versions listed below:
 
-- `AutoGluon-Cloud 0.5.0 (dev) documentation  <https://auto.gluon.ai/cloud/dev/index.html>`_
-- `AutoGluon-Cloud 0.4.2 (stable) documentation  <https://auto.gluon.ai/cloud/stable/index.html>`_
-- `AutoGluon-Cloud 0.4.1 documentation  <https://auto.gluon.ai/cloud/0.4.1/index.html>`_
-- `AutoGluon-Cloud 0.4.0 documentation <https://auto.gluon.ai/cloud/0.4.0/index.html>`_
-- `AutoGluon-Cloud 0.3.1 documentation <https://auto.gluon.ai/cloud/0.3.1/index.html>`_
-- `AutoGluon-Cloud 0.3.0 documentation <https://auto.gluon.ai/cloud/0.3.0/index.html>`_
-- `AutoGluon-Cloud 0.2.0 documentation <https://auto.gluon.ai/cloud/0.2.0/index.html>`_
-- `AutoGluon-Cloud 0.1.0 documentation <https://auto.gluon.ai/cloud/0.1.0/index.html>`_
+- `AutoGluon-Cloud 0.5.0 (stable) documentation  <https://auto.gluon.ai/cloud/stable/index.html>`_
+- `AutoGluon-Cloud 0.4.2 documentation  <https://auto.gluon.ai/cloud/v0.4.2/index.html>`_
+- `AutoGluon-Cloud 0.4.1 documentation  <https://auto.gluon.ai/cloud/v0.4.1/index.html>`_
+- `AutoGluon-Cloud 0.4.0 documentation <https://auto.gluon.ai/cloud/v0.4.0/index.html>`_
+- `AutoGluon-Cloud 0.3.1 documentation <https://auto.gluon.ai/cloud/v0.3.1/index.html>`_
+- `AutoGluon-Cloud 0.3.0 documentation <https://auto.gluon.ai/cloud/v0.3.0/index.html>`_
+- `AutoGluon-Cloud 0.2.0 documentation <https://auto.gluon.ai/cloud/v0.2.0/index.html>`_
+- `AutoGluon-Cloud 0.1.0 documentation <https://auto.gluon.ai/cloud/v0.1.0/index.html>`_

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup
 AUTOGLUON = "autogluon"
 CLOUD = "cloud"
 
-PYTHON_REQUIRES = ">=3.10, <3.13"
+PYTHON_REQUIRES = ">=3.10, <3.14"
 
 
 def create_version_file(*, version):
@@ -85,10 +85,10 @@ def default_setup_args(*, version):
             "Operating System :: POSIX",
             "Operating System :: Unix",
             "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.9",
             "Programming Language :: Python :: 3.10",
             "Programming Language :: Python :: 3.11",
             "Programming Language :: Python :: 3.12",
+            "Programming Language :: Python :: 3.13",
             "Topic :: Software Development",
             "Topic :: Scientific/Engineering :: Artificial Intelligence",
             "Topic :: Scientific/Engineering :: Information Analysis",

--- a/src/autogluon/cloud/endpoint/timeseries_endpoint.py
+++ b/src/autogluon/cloud/endpoint/timeseries_endpoint.py
@@ -1,27 +1,48 @@
 from typing import Any, Dict, List, Optional, Union
 
+import boto3
 import pandas as pd
+import sagemaker
+from sagemaker.predictor import Predictor
 
 from autogluon.common.loaders import load_pd
 
-from ..utils.serializers import AutoGluonSerializationWrapper
-from .endpoint import Endpoint
+from ..utils.deserializers import PandasDeserializer
+from ..utils.serializers import AutoGluonSerializationWrapper, AutoGluonSerializer
 
 
 class TimeSeriesEndpoint:
-    """High-level endpoint for time series prediction.
+    """High-level handle for an AutoGluon-Cloud time series inference endpoint.
 
-    Wraps an Endpoint and handles serialization/deserialization,
-    providing a clean predict() interface.
+    Wraps a SageMaker endpoint with the AutoGluon-Cloud serializer/deserializer pair, providing a clean
+    :meth:`predict` interface. Use this to attach to an existing endpoint by name. To create a new endpoint, call
+    :meth:`autogluon.cloud.TimeSeriesFoundationModel.deploy`, which returns a :class:`TimeSeriesEndpoint` already
+    pointing at the new endpoint.
     """
 
-    def __init__(self, endpoint: Endpoint):
-        # TODO: replace with sagemaker.Predictor directly (remove Endpoint/SagemakerEndpoint layer)
-        self._endpoint = endpoint
+    def __init__(self, endpoint_name: str, session: Optional[boto3.Session] = None):
+        """
+        Parameters
+        ----------
+        endpoint_name
+            Name of an existing SageMaker endpoint deployed via AutoGluon-Cloud (e.g. through
+            :meth:`autogluon.cloud.TimeSeriesFoundationModel.deploy`). The endpoint must understand the AutoGluon-Cloud
+            request payload format.
+        session
+            ``boto3.Session`` used to invoke and delete the endpoint. If ``None``, the default ambient session is used.
+        """
+        boto_session = session or boto3.Session()
+        sagemaker_session = sagemaker.Session(boto_session=boto_session)
+        self._predictor = Predictor(
+            endpoint_name=endpoint_name,
+            sagemaker_session=sagemaker_session,
+            serializer=AutoGluonSerializer(),
+            deserializer=PandasDeserializer(),
+        )
 
     @property
     def endpoint_name(self) -> str:
-        return self._endpoint.endpoint_name
+        return self._predictor.endpoint_name
 
     def predict(
         self,
@@ -41,8 +62,8 @@ class TimeSeriesEndpoint:
         Parameters
         ----------
         data
-            Historical time series to forecast from, in long format, as a DataFrame or local/S3 path to
-            a data file. See the `TimeSeriesPredictor docs <https://auto.gluon.ai/stable/api/autogluon.timeseries.TimeSeriesPredictor.html>`_
+            Historical time series to forecast from, in long format, as a DataFrame or local/S3 path to a data file.
+            See the `TimeSeriesPredictor docs <https://auto.gluon.ai/stable/api/autogluon.timeseries.TimeSeriesPredictor.html>`_
             for the expected format.
         known_covariates
             Future values of the known covariates over the forecast horizon.
@@ -57,8 +78,8 @@ class TimeSeriesEndpoint:
         timestamp_column
             Name of the column with the observation timestamps.
         quantile_levels
-            List of increasing decimals between 0 and 1 specifying which quantiles to estimate. Defaults
-            to ``[0.1, 0.2, ..., 0.9]``.
+            List of increasing decimals between 0 and 1 specifying which quantiles to estimate. Defaults to
+            ``[0.1, 0.2, ..., 0.9]``.
         accept
             Response format. Options: 'application/x-parquet', 'text/csv', 'application/json'.
 
@@ -88,8 +109,9 @@ class TimeSeriesEndpoint:
             static_features=static_features,
             known_covariates=known_covariates,
         )
-        return self._endpoint.predict(payload, initial_args={"Accept": accept})
+        return self._predictor.predict(payload, initial_args={"Accept": accept})
 
     def delete_endpoint(self) -> None:
-        """Delete the endpoint and cleanup artifacts."""
-        self._endpoint.delete_endpoint()
+        """Delete the endpoint and its backing model + endpoint config."""
+        self._predictor.delete_model()
+        self._predictor.delete_endpoint(delete_endpoint_config=True)

--- a/src/autogluon/cloud/model/foundation_model.py
+++ b/src/autogluon/cloud/model/foundation_model.py
@@ -453,7 +453,10 @@ class TimeSeriesFoundationModel(FoundationModel):
             inference_config=inference_config,
             **backend_kwargs,
         )
-        return TimeSeriesEndpoint(self._backend.endpoint)
+        return TimeSeriesEndpoint(
+            endpoint_name=self._backend.endpoint.endpoint_name,
+            session=self._backend.sagemaker_session.boto_session,
+        )
 
     def _build_predictor_fit_args(self, hyperparameters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         merged_hp = self._get_hyperparameters("inference", hyperparameters)


### PR DESCRIPTION
Issue #, if available: #245

Description of changes:
- Reshape `TimeSeriesEndpoint` constructor to take `endpoint_name: str` (plus optional `boto3.Session`) so users can reattach to an existing endpoint without poking through `SagemakerEndpoint` / `Predictor` / serializers.
`TimeSeriesFoundationModel.deploy()` updated to use the new signature.
- Add a "Reattaching to an existing endpoint" section to the FM tutorial.
- Bump supported Python to `<3.14` and refresh the classifier list.
- Bump docs `release` to `0.5.0`; promote `0.5.0` to stable in `versions.rst` and fix the legacy version links to use the `v<x.y.z>` path.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
