### PR TITLE
Fix FoundationModel endpoint deployment after batch prediction

### DIFF
--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -452,11 +452,8 @@ class SagemakerBackend(Backend):
             )
             volume_size = None
 
-        # Resolve model artifact:
-        # - predictor_path provided → use as-is
-        # - predictor_path=None, fit job exists → use fit output
-        # - predictor_path=None, no fit job → no artifact (FM: weights downloaded at startup)
-        if predictor_path is None and self._fit_job is not None:
+        # Reuse the fit-job tarball only for non-FM deploys — FM deploys need their own serve script.
+        if predictor_path is None and self._fit_job is not None and fm_serve_config is None:
             predictor_path = self._fit_job.get_output_path()
         if predictor_path:
             predictor_path = self._upload_predictor(predictor_path, f"endpoints/{endpoint_name}/predictor")

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -452,7 +452,10 @@ class SagemakerBackend(Backend):
             )
             volume_size = None
 
-        # Reuse the fit-job tarball only for non-FM deploys — FM deploys need their own serve script.
+        # Resolve model artifact:
+        # - predictor_path provided → use as-is
+        # - predictor_path=None, fit job exists, non-FM deploy → use fit output
+        # - predictor_path=None, no fit job (or FM deploy) → no artifact
         if predictor_path is None and self._fit_job is not None and fm_serve_config is None:
             predictor_path = self._fit_job.get_output_path()
         if predictor_path:


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Fix a bug where we accidentally reused the fit job output during FM deployment

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
