### PR TITLE
Add fit_predict / fit_predict_proba to TabularCloudPredictor

### DIFF
--- a/src/autogluon/cloud/backend/tabular_sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/tabular_sagemaker_backend.py
@@ -1,4 +1,3 @@
-import logging
 import os
 from typing import Any, Dict, Optional, Union
 
@@ -9,16 +8,9 @@ from autogluon.common.loaders import load_pd
 from .constant import TABULAR_SAGEMAKER
 from .sagemaker_backend import SagemakerBackend
 
-logger = logging.getLogger(__name__)
-
 
 class TabularSagemakerBackend(SagemakerBackend):
     name = TABULAR_SAGEMAKER
-
-    def parse_backend_fit_kwargs(self, kwargs: Dict) -> Dict[str, Any]:
-        parsed = super().parse_backend_fit_kwargs(kwargs)
-        parsed["test_data"] = kwargs.get("test_data", None)
-        return parsed
 
     def fit(
         self,
@@ -26,57 +18,45 @@ class TabularSagemakerBackend(SagemakerBackend):
         predictor_init_args: Dict[str, Any],
         predictor_fit_args: Dict[str, Any],
         data_channels: Dict[str, Optional[Union[str, pd.DataFrame]]],
-        test_data: Optional[Union[str, pd.DataFrame]] = None,
-        extra_ag_args: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> None:
-        """Fit a TabularPredictor in SageMaker.
-
-        ``test_data`` (if present in ``data_channels`` or passed explicitly) is only honored when
-        ``extra_ag_args["predict_after_fit"]`` is True, in which case the training container also runs
-        in-job prediction on it (the ``fit_predict`` path).
-        """
-        extra_ag_args = dict(extra_ag_args or {})
-        if test_data is not None:
-            if not extra_ag_args.get("predict_after_fit", False):
-                raise ValueError("`test_data` should only be provided if `predict_after_fit=True`.")
-            data_channels = dict(data_channels)
-            data_channels["test_data"] = self._validate_test_data(
-                train_data=data_channels["train_data"],
-                test_data=test_data,
-                predictor_init_args=predictor_init_args,
-            )
-
+        data_channels = self._validate_data_channels(
+            data_channels=data_channels,
+            predictor_init_args=predictor_init_args,
+        )
         super().fit(
             predictor_init_args=predictor_init_args,
             predictor_fit_args=predictor_fit_args,
             data_channels=data_channels,
-            extra_ag_args=extra_ag_args,
             **kwargs,
         )
 
-    def _validate_test_data(
+    def _validate_data_channels(
         self,
         *,
-        train_data: Union[str, pd.DataFrame],
-        test_data: Union[str, pd.DataFrame],
+        data_channels: Dict[str, Optional[Union[str, pd.DataFrame]]],
         predictor_init_args: Dict[str, Any],
-    ) -> pd.DataFrame:
-        """Validate ``test_data`` client-side before launching the SageMaker job.
+    ) -> Dict[str, Optional[Union[str, pd.DataFrame]]]:
+        """Validate tabular data channels client-side before launching the SageMaker job.
+
+        Resolves ``str`` paths via ``load_pd.load`` so column checks can run, and returns the (possibly loaded)
+        channel dict for the caller to reuse.
 
         A fused fit_predict job means a schema typo wastes the whole training run, so we check up front that
-        ``test_data`` covers every training feature column (the train columns minus the label). Returns the
-        (possibly loaded) ``test_data`` DataFrame so the caller can reuse it as a data channel.
+        ``test_data`` (if present) covers every training feature column (the train columns minus the label).
         """
-        if isinstance(train_data, (str, os.PathLike)):
-            train_data = load_pd.load(str(train_data))
-        if isinstance(test_data, (str, os.PathLike)):
-            test_data = load_pd.load(str(test_data))
+        loaded: Dict[str, Optional[Union[str, pd.DataFrame]]] = {}
+        for name, df in data_channels.items():
+            if isinstance(df, (str, os.PathLike)):
+                df = load_pd.load(str(df))
+            loaded[name] = df
 
-        label = predictor_init_args.get("label")
-        feature_columns = [c for c in train_data.columns if c != label]
-        missing_columns = [c for c in feature_columns if c not in test_data.columns]
-        if missing_columns:
-            raise ValueError(f"`test_data` is missing feature columns present in `train_data`: {missing_columns}.")
+        test_data = loaded.get("test_data")
+        if test_data is not None:
+            label = predictor_init_args.get("label")
+            feature_columns = [c for c in loaded["train_data"].columns if c != label]
+            missing_columns = [c for c in feature_columns if c not in test_data.columns]
+            if missing_columns:
+                raise ValueError(f"`test_data` is missing feature columns present in `train_data`: {missing_columns}.")
 
-        return test_data
+        return loaded

--- a/src/autogluon/cloud/backend/tabular_sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/tabular_sagemaker_backend.py
@@ -36,16 +36,16 @@ class TabularSagemakerBackend(SagemakerBackend):
         *,
         data_channels: Dict[str, Optional[Union[str, pd.DataFrame]]],
         predictor_init_args: Dict[str, Any],
-    ) -> Dict[str, Optional[Union[str, pd.DataFrame]]]:
+    ) -> Dict[str, Optional[pd.DataFrame]]:
         """Validate tabular data channels client-side before launching the SageMaker job.
 
-        Resolves ``str`` paths via ``load_pd.load`` so column checks can run, and returns the (possibly loaded)
-        channel dict for the caller to reuse.
+        Resolves path inputs via ``load_pd.load`` so column checks can run, and returns the loaded channel
+        dict for the caller to reuse.
 
         A fused fit_predict job means a schema typo wastes the whole training run, so we check up front that
         ``test_data`` (if present) covers every training feature column (the train columns minus the label).
         """
-        loaded: Dict[str, Optional[Union[str, pd.DataFrame]]] = {}
+        loaded: Dict[str, Optional[pd.DataFrame]] = {}
         for name, df in data_channels.items():
             if isinstance(df, (str, os.PathLike)):
                 df = load_pd.load(str(df))
@@ -53,7 +53,7 @@ class TabularSagemakerBackend(SagemakerBackend):
 
         test_data = loaded.get("test_data")
         if test_data is not None:
-            label = predictor_init_args.get("label")
+            label = predictor_init_args["label"]
             feature_columns = [c for c in loaded["train_data"].columns if c != label]
             missing_columns = [c for c in feature_columns if c not in test_data.columns]
             if missing_columns:

--- a/src/autogluon/cloud/backend/tabular_sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/tabular_sagemaker_backend.py
@@ -51,9 +51,14 @@ class TabularSagemakerBackend(SagemakerBackend):
                 df = load_pd.load(str(df))
             loaded[name] = df
 
+        if "label" not in predictor_init_args:
+            raise ValueError("`predictor_init_args` must contain `label` for a Tabular predictor.")
+        label = predictor_init_args["label"]
+        if label not in loaded["train_data"].columns:
+            raise ValueError(f"Label column {label!r} is not present in `train_data`.")
+
         test_data = loaded.get("test_data")
         if test_data is not None:
-            label = predictor_init_args["label"]
             feature_columns = [c for c in loaded["train_data"].columns if c != label]
             missing_columns = [c for c in feature_columns if c not in test_data.columns]
             if missing_columns:

--- a/src/autogluon/cloud/backend/tabular_sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/tabular_sagemaker_backend.py
@@ -1,6 +1,82 @@
+import logging
+import os
+from typing import Any, Dict, Optional, Union
+
+import pandas as pd
+
+from autogluon.common.loaders import load_pd
+
 from .constant import TABULAR_SAGEMAKER
 from .sagemaker_backend import SagemakerBackend
+
+logger = logging.getLogger(__name__)
 
 
 class TabularSagemakerBackend(SagemakerBackend):
     name = TABULAR_SAGEMAKER
+
+    def parse_backend_fit_kwargs(self, kwargs: Dict) -> Dict[str, Any]:
+        parsed = super().parse_backend_fit_kwargs(kwargs)
+        parsed["test_data"] = kwargs.get("test_data", None)
+        return parsed
+
+    def fit(
+        self,
+        *,
+        predictor_init_args: Dict[str, Any],
+        predictor_fit_args: Dict[str, Any],
+        data_channels: Dict[str, Optional[Union[str, pd.DataFrame]]],
+        test_data: Optional[Union[str, pd.DataFrame]] = None,
+        extra_ag_args: Optional[Dict[str, Any]] = None,
+        **kwargs,
+    ) -> None:
+        """Fit a TabularPredictor in SageMaker.
+
+        ``test_data`` (if present in ``data_channels`` or passed explicitly) is only honored when
+        ``extra_ag_args["predict_after_fit"]`` is True, in which case the training container also runs
+        in-job prediction on it (the ``fit_predict`` path).
+        """
+        extra_ag_args = dict(extra_ag_args or {})
+        if test_data is not None:
+            if not extra_ag_args.get("predict_after_fit", False):
+                raise ValueError("`test_data` should only be provided if `predict_after_fit=True`.")
+            data_channels = dict(data_channels)
+            data_channels["test_data"] = self._validate_test_data(
+                train_data=data_channels["train_data"],
+                test_data=test_data,
+                predictor_init_args=predictor_init_args,
+            )
+
+        super().fit(
+            predictor_init_args=predictor_init_args,
+            predictor_fit_args=predictor_fit_args,
+            data_channels=data_channels,
+            extra_ag_args=extra_ag_args,
+            **kwargs,
+        )
+
+    def _validate_test_data(
+        self,
+        *,
+        train_data: Union[str, pd.DataFrame],
+        test_data: Union[str, pd.DataFrame],
+        predictor_init_args: Dict[str, Any],
+    ) -> pd.DataFrame:
+        """Validate ``test_data`` client-side before launching the SageMaker job.
+
+        A fused fit_predict job means a schema typo wastes the whole training run, so we check up front that
+        ``test_data`` covers every training feature column (the train columns minus the label). Returns the
+        (possibly loaded) ``test_data`` DataFrame so the caller can reuse it as a data channel.
+        """
+        if isinstance(train_data, (str, os.PathLike)):
+            train_data = load_pd.load(str(train_data))
+        if isinstance(test_data, (str, os.PathLike)):
+            test_data = load_pd.load(str(test_data))
+
+        label = predictor_init_args.get("label")
+        feature_columns = [c for c in train_data.columns if c != label]
+        missing_columns = [c for c in feature_columns if c not in test_data.columns]
+        if missing_columns:
+            raise ValueError(f"`test_data` is missing feature columns present in `train_data`: {missing_columns}.")
+
+        return test_data

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -177,6 +177,7 @@ class CloudPredictor(ABC):
         timeout: int = 24 * 60 * 60,
         wait: bool = True,
         backend_kwargs: Optional[Dict] = None,
+        **kwargs,
     ) -> CloudPredictor:
         """
         Fit the predictor with the backend.
@@ -250,8 +251,13 @@ class CloudPredictor(ABC):
         )
         if backend_kwargs is None:
             backend_kwargs = {}
+        # `test_data` is an internal channel for the fit_predict path (see TabularCloudPredictor.fit_predict_proba);
+        # it is intentionally not part of the public `fit()` signature.
+        test_data = kwargs.pop("test_data", None)
+        if kwargs:
+            raise TypeError(f"fit() got unexpected keyword arguments: {sorted(kwargs)}")
         predictor_fit_args = {} if predictor_fit_args is None else dict(predictor_fit_args)
-        data_channels = {"train_data": train_data, "tuning_data": tuning_data}
+        data_channels = {"train_data": train_data, "tuning_data": tuning_data, "test_data": test_data}
         for key in ("train_data", "tuning_data"):
             if key in predictor_fit_args:
                 warnings.warn(

--- a/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -1,6 +1,13 @@
+from __future__ import annotations
+
 import logging
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple, Union
+
+import pandas as pd
 
 from ..backend.constant import RAY_AWS, SAGEMAKER, TABULAR_RAY_AWS, TABULAR_SAGEMAKER
+from ..utils.utils import split_pred_and_pred_proba
 from .cloud_predictor import CloudPredictor
 
 logger = logging.getLogger(__name__)
@@ -28,3 +35,271 @@ class TabularCloudPredictor(CloudPredictor):
 
         predictor_cls = TabularPredictor
         return predictor_cls
+
+    def fit_predict(
+        self,
+        train_data: Union[str, Path, pd.DataFrame],
+        test_data: Union[str, Path, pd.DataFrame],
+        *,
+        predictor_init_args: Dict[str, Any],
+        predictor_fit_args: Optional[Dict[str, Any]] = None,
+        leaderboard: bool = True,
+        framework_version: str = "latest",
+        job_name: Optional[str] = None,
+        instance_type: str = "ml.m5.2xlarge",
+        instance_count: int = 1,
+        volume_size: int = 256,
+        custom_image_uri: Optional[str] = None,
+        wait: bool = True,
+        predictions_path: Optional[str] = None,
+        backend_kwargs: Optional[Dict] = None,
+    ) -> Optional[pd.Series]:
+        """
+        Fit and predict in a single SageMaker training job.
+
+        Fits a ``TabularPredictor`` on ``train_data`` and runs batch prediction on ``test_data`` inside the same
+        training container. This avoids the overhead of a separate batch-transform job (one cold start, one data
+        upload, no predictor-tarball round-trip). The predictor is left fitted afterward, so ``deploy()`` /
+        ``predict()`` still work.
+
+        Parameters
+        ----------
+        train_data: Union[str, pathlib.Path, pd.DataFrame]
+            Training data, as a DataFrame or local/S3 path to a data file.
+        test_data: Union[str, pathlib.Path, pd.DataFrame]
+            Data to predict on, as a DataFrame or local/S3 path to a data file. Must contain every feature
+            column present in ``train_data`` (the label column is not required).
+        predictor_init_args: dict
+            Init args for the predictor.
+        predictor_fit_args: Optional[dict], default = None
+            Additional fit args forwarded to ``TabularPredictor.fit()``. Must NOT contain ``train_data`` or
+            ``tuning_data``.
+        leaderboard: bool, default = True
+            Whether to include the leaderboard in the output artifact.
+        framework_version: str, default = `latest`
+            Training container version of autogluon. If `latest`, will use the latest available container version.
+            If `custom_image_uri` is set, this argument will be ignored.
+        job_name: str, default = None
+            Name of the launched training job. If None, CloudPredictor will create one with prefix ag-cloudpredictor.
+        instance_type: str, default = 'ml.m5.2xlarge'
+            Instance type the predictor will be trained on with SageMaker.
+        instance_count: int, default = 1
+            Number of instances used to fit the predictor.
+        volume_size: int, default = 256
+            Size in GB of the EBS volume to use for storing input data during training.
+        custom_image_uri: Optional[str], default = None
+            Custom container image URI. If set, ``framework_version`` is ignored.
+        wait: bool, default = True
+            Whether the call should wait until the job completes.
+        predictions_path: Optional[str]
+            S3 URL where predictions will be written by the training container (e.g.
+            ``s3://my-bucket/runs/2024-05-01/predictions.csv``). Defaults to
+            ``{cloud_output_path}/{job_name}/predictions.csv``.
+        backend_kwargs: Optional[dict], default = None
+            Backend-specific arguments. Same keys as ``fit()``.
+
+        Returns
+        -------
+        Optional[pd.Series]
+            Predictions as a Series. Returns ``None`` when ``wait`` is False; fetch later via
+            ``get_fit_predict_results()``.
+        """
+        self._fit_for_predict(
+            train_data=train_data,
+            test_data=test_data,
+            predictor_init_args=predictor_init_args,
+            predictor_fit_args=predictor_fit_args,
+            leaderboard=leaderboard,
+            framework_version=framework_version,
+            job_name=job_name,
+            instance_type=instance_type,
+            instance_count=instance_count,
+            volume_size=volume_size,
+            custom_image_uri=custom_image_uri,
+            wait=wait,
+            predictions_path=predictions_path,
+            backend_kwargs=backend_kwargs,
+        )
+
+        if not wait:
+            logger.info(
+                "fit_predict job launched asynchronously. Use `get_fit_job_status()` "
+                "to poll, then `get_fit_predict_results()` to fetch predictions."
+            )
+            return None
+
+        return self.get_fit_predict_results()
+
+    def fit_predict_proba(
+        self,
+        train_data: Union[str, Path, pd.DataFrame],
+        test_data: Union[str, Path, pd.DataFrame],
+        *,
+        predictor_init_args: Dict[str, Any],
+        predictor_fit_args: Optional[Dict[str, Any]] = None,
+        include_predict: bool = True,
+        leaderboard: bool = True,
+        framework_version: str = "latest",
+        job_name: Optional[str] = None,
+        instance_type: str = "ml.m5.2xlarge",
+        instance_count: int = 1,
+        volume_size: int = 256,
+        custom_image_uri: Optional[str] = None,
+        wait: bool = True,
+        predictions_path: Optional[str] = None,
+        backend_kwargs: Optional[Dict] = None,
+    ) -> Optional[Union[Tuple[pd.Series, Union[pd.DataFrame, pd.Series]], Union[pd.DataFrame, pd.Series]]]:
+        """
+        Fit and predict probabilities in a single SageMaker training job.
+
+        Identical to :meth:`fit_predict` but returns class probabilities. For regression the probabilities are
+        identical to the predictions (same as :meth:`predict_proba`).
+
+        Parameters
+        ----------
+        train_data: Union[str, pathlib.Path, pd.DataFrame]
+            Training data, as a DataFrame or local/S3 path to a data file.
+        test_data: Union[str, pathlib.Path, pd.DataFrame]
+            Data to predict on. Must contain every feature column present in ``train_data``.
+        predictor_init_args: dict
+            Init args for the predictor.
+        predictor_fit_args: Optional[dict], default = None
+            Additional fit args forwarded to ``TabularPredictor.fit()``.
+        include_predict: bool, default = True
+            Whether to return the predictions along with the probabilities. Comes for free — the job always
+            computes both.
+        leaderboard: bool, default = True
+            Whether to include the leaderboard in the output artifact.
+        framework_version: str, default = `latest`
+            Training container version of autogluon. If `custom_image_uri` is set, this argument is ignored.
+        job_name: str, default = None
+            Name of the launched training job. If None, CloudPredictor will create one with prefix ag-cloudpredictor.
+        instance_type: str, default = 'ml.m5.2xlarge'
+            Instance type the predictor will be trained on with SageMaker.
+        instance_count: int, default = 1
+            Number of instances used to fit the predictor.
+        volume_size: int, default = 256
+            Size in GB of the EBS volume to use for storing input data during training.
+        custom_image_uri: Optional[str], default = None
+            Custom container image URI. If set, ``framework_version`` is ignored.
+        wait: bool, default = True
+            Whether the call should wait until the job completes.
+        predictions_path: Optional[str]
+            S3 URL where predictions will be written by the training container. Defaults to
+            ``{cloud_output_path}/{job_name}/predictions.csv``.
+        backend_kwargs: Optional[dict], default = None
+            Backend-specific arguments. Same keys as ``fit()``.
+
+        Returns
+        -------
+        Optional[Union[Tuple[pd.Series, Union[pd.DataFrame, pd.Series]], Union[pd.DataFrame, pd.Series]]]
+            If ``include_predict`` is True, returns ``(prediction, predict_probability)``; otherwise just
+            ``predict_probability``. Returns ``None`` when ``wait`` is False; fetch later via
+            ``get_fit_predict_proba_results()``.
+        """
+        self._fit_for_predict(
+            train_data=train_data,
+            test_data=test_data,
+            predictor_init_args=predictor_init_args,
+            predictor_fit_args=predictor_fit_args,
+            leaderboard=leaderboard,
+            framework_version=framework_version,
+            job_name=job_name,
+            instance_type=instance_type,
+            instance_count=instance_count,
+            volume_size=volume_size,
+            custom_image_uri=custom_image_uri,
+            wait=wait,
+            predictions_path=predictions_path,
+            backend_kwargs=backend_kwargs,
+        )
+
+        if not wait:
+            logger.info(
+                "fit_predict_proba job launched asynchronously. Use `get_fit_job_status()` "
+                "to poll, then `get_fit_predict_proba_results()` to fetch probabilities."
+            )
+            return None
+
+        return self.get_fit_predict_proba_results(include_predict=include_predict)
+
+    def _fit_for_predict(
+        self,
+        *,
+        train_data,
+        test_data,
+        predictor_init_args,
+        predictor_fit_args,
+        leaderboard,
+        framework_version,
+        job_name,
+        instance_type,
+        instance_count,
+        volume_size,
+        custom_image_uri,
+        wait,
+        predictions_path,
+        backend_kwargs,
+    ) -> None:
+        """Launch a fit + in-job-predict training job shared by ``fit_predict`` / ``fit_predict_proba``."""
+        backend_kwargs = {} if backend_kwargs is None else dict(backend_kwargs)
+        extra_ag_args = dict(backend_kwargs.get("extra_ag_args") or {})
+        extra_ag_args["predict_after_fit"] = True
+        if predictions_path is not None:
+            extra_ag_args["predictions_path"] = predictions_path
+        backend_kwargs["extra_ag_args"] = extra_ag_args
+        backend_kwargs["test_data"] = test_data
+
+        self.fit(
+            train_data=train_data,
+            predictor_init_args=predictor_init_args,
+            predictor_fit_args=predictor_fit_args,
+            leaderboard=leaderboard,
+            framework_version=framework_version,
+            job_name=job_name,
+            instance_type=instance_type,
+            instance_count=instance_count,
+            volume_size=volume_size,
+            custom_image_uri=custom_image_uri,
+            wait=wait,
+            backend_kwargs=backend_kwargs,
+        )
+
+    def get_fit_predict_results(self) -> pd.Series:
+        """
+        Retrieve predictions produced by a completed ``fit_predict`` job.
+
+        Returns
+        -------
+        pd.Series
+            Predictions for ``test_data``.
+        """
+        raw = self.backend.get_fit_predict_results()
+        pred, _ = split_pred_and_pred_proba(raw)
+        return pred
+
+    def get_fit_predict_proba_results(
+        self, include_predict: bool = True
+    ) -> Union[Tuple[pd.Series, Union[pd.DataFrame, pd.Series]], Union[pd.DataFrame, pd.Series]]:
+        """
+        Retrieve probabilities produced by a completed ``fit_predict_proba`` job.
+
+        Parameters
+        ----------
+        include_predict: bool, default = True
+            Whether to return the predictions along with the probabilities.
+
+        Returns
+        -------
+        Union[Tuple[pd.Series, Union[pd.DataFrame, pd.Series]], Union[pd.DataFrame, pd.Series]]
+            If ``include_predict`` is True, returns ``(prediction, predict_probability)``; otherwise just
+            ``predict_probability``. For regression the probabilities are identical to the predictions.
+        """
+        raw = self.backend.get_fit_predict_results()
+        pred, pred_proba = split_pred_and_pred_proba(raw)
+        # Regression: the job writes only the prediction column, so proba mirrors pred (matches predict_proba).
+        if pred_proba is None:
+            pred_proba = pred
+        if include_predict:
+            return pred, pred_proba
+        return pred_proba

--- a/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -104,11 +104,12 @@ class TabularCloudPredictor(CloudPredictor):
             Predictions as a Series. Returns ``None`` when ``wait`` is False; fetch later via
             ``get_fit_predict_results()``.
         """
-        self._fit_for_predict(
+        result = self.fit_predict_proba(
             train_data=train_data,
             test_data=test_data,
             predictor_init_args=predictor_init_args,
             predictor_fit_args=predictor_fit_args,
+            include_predict=True,
             leaderboard=leaderboard,
             framework_version=framework_version,
             job_name=job_name,
@@ -120,15 +121,10 @@ class TabularCloudPredictor(CloudPredictor):
             predictions_path=predictions_path,
             backend_kwargs=backend_kwargs,
         )
-
-        if not wait:
-            logger.info(
-                "fit_predict job launched asynchronously. Use `get_fit_job_status()` "
-                "to poll, then `get_fit_predict_results()` to fetch predictions."
-            )
+        if result is None:  # wait=False
             return None
-
-        return self.get_fit_predict_results()
+        pred, _ = result
+        return pred
 
     def fit_predict_proba(
         self,
@@ -197,7 +193,14 @@ class TabularCloudPredictor(CloudPredictor):
             ``predict_probability``. Returns ``None`` when ``wait`` is False; fetch later via
             ``get_fit_predict_proba_results()``.
         """
-        self._fit_for_predict(
+        backend_kwargs = {} if backend_kwargs is None else dict(backend_kwargs)
+        extra_ag_args = dict(backend_kwargs.get("extra_ag_args") or {})
+        extra_ag_args["predict_after_fit"] = True
+        if predictions_path is not None:
+            extra_ag_args["predictions_path"] = predictions_path
+        backend_kwargs["extra_ag_args"] = extra_ag_args
+
+        self.fit(
             train_data=train_data,
             test_data=test_data,
             predictor_init_args=predictor_init_args,
@@ -210,7 +213,6 @@ class TabularCloudPredictor(CloudPredictor):
             volume_size=volume_size,
             custom_image_uri=custom_image_uri,
             wait=wait,
-            predictions_path=predictions_path,
             backend_kwargs=backend_kwargs,
         )
 
@@ -222,48 +224,6 @@ class TabularCloudPredictor(CloudPredictor):
             return None
 
         return self.get_fit_predict_proba_results(include_predict=include_predict)
-
-    def _fit_for_predict(
-        self,
-        *,
-        train_data,
-        test_data,
-        predictor_init_args,
-        predictor_fit_args,
-        leaderboard,
-        framework_version,
-        job_name,
-        instance_type,
-        instance_count,
-        volume_size,
-        custom_image_uri,
-        wait,
-        predictions_path,
-        backend_kwargs,
-    ) -> None:
-        """Launch a fit + in-job-predict training job shared by ``fit_predict`` / ``fit_predict_proba``."""
-        backend_kwargs = {} if backend_kwargs is None else dict(backend_kwargs)
-        extra_ag_args = dict(backend_kwargs.get("extra_ag_args") or {})
-        extra_ag_args["predict_after_fit"] = True
-        if predictions_path is not None:
-            extra_ag_args["predictions_path"] = predictions_path
-        backend_kwargs["extra_ag_args"] = extra_ag_args
-        backend_kwargs["test_data"] = test_data
-
-        self.fit(
-            train_data=train_data,
-            predictor_init_args=predictor_init_args,
-            predictor_fit_args=predictor_fit_args,
-            leaderboard=leaderboard,
-            framework_version=framework_version,
-            job_name=job_name,
-            instance_type=instance_type,
-            instance_count=instance_count,
-            volume_size=volume_size,
-            custom_image_uri=custom_image_uri,
-            wait=wait,
-            backend_kwargs=backend_kwargs,
-        )
 
     def get_fit_predict_results(self) -> pd.Series:
         """

--- a/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/tabular_cloud_predictor.py
@@ -218,12 +218,15 @@ class TabularCloudPredictor(CloudPredictor):
 
         if not wait:
             logger.info(
-                "fit_predict_proba job launched asynchronously. Use `get_fit_job_status()` "
-                "to poll, then `get_fit_predict_proba_results()` to fetch probabilities."
+                "fit_predict job launched asynchronously. Use `get_fit_job_status()` to poll, then "
+                "`get_fit_predict_results()` / `get_fit_predict_proba_results()` to fetch the results."
             )
             return None
 
-        return self.get_fit_predict_proba_results(include_predict=include_predict)
+        pred, pred_proba = self.get_fit_predict_proba_results()
+        if include_predict:
+            return pred, pred_proba
+        return pred_proba
 
     def get_fit_predict_results(self) -> pd.Series:
         """
@@ -234,32 +237,22 @@ class TabularCloudPredictor(CloudPredictor):
         pd.Series
             Predictions for ``test_data``.
         """
-        raw = self.backend.get_fit_predict_results()
-        pred, _ = split_pred_and_pred_proba(raw)
+        pred, _ = self.get_fit_predict_proba_results()
         return pred
 
-    def get_fit_predict_proba_results(
-        self, include_predict: bool = True
-    ) -> Union[Tuple[pd.Series, Union[pd.DataFrame, pd.Series]], Union[pd.DataFrame, pd.Series]]:
+    def get_fit_predict_proba_results(self) -> Tuple[pd.Series, Union[pd.DataFrame, pd.Series]]:
         """
-        Retrieve probabilities produced by a completed ``fit_predict_proba`` job.
-
-        Parameters
-        ----------
-        include_predict: bool, default = True
-            Whether to return the predictions along with the probabilities.
+        Retrieve predictions and probabilities produced by a completed ``fit_predict_proba`` job.
 
         Returns
         -------
-        Union[Tuple[pd.Series, Union[pd.DataFrame, pd.Series]], Union[pd.DataFrame, pd.Series]]
-            If ``include_predict`` is True, returns ``(prediction, predict_probability)``; otherwise just
-            ``predict_probability``. For regression the probabilities are identical to the predictions.
+        Tuple[pd.Series, Union[pd.DataFrame, pd.Series]]
+            ``(prediction, predict_probability)``. For regression the probabilities are identical to the
+            predictions.
         """
         raw = self.backend.get_fit_predict_results()
         pred, pred_proba = split_pred_and_pred_proba(raw)
         # Regression: the job writes only the prediction column, so proba mirrors pred (matches predict_proba).
         if pred_proba is None:
             pred_proba = pred
-        if include_predict:
-            return pred, pred_proba
-        return pred_proba
+        return pred, pred_proba

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/tabular_serve.py
@@ -8,8 +8,6 @@ from io import BytesIO, StringIO
 import pandas as pd
 from PIL import Image
 
-from autogluon.core.constants import QUANTILE, REGRESSION
-from autogluon.core.utils import get_pred_from_proba_df
 from autogluon.tabular import TabularPredictor
 
 image_dir = os.path.join("/tmp", "ag_images")
@@ -85,9 +83,9 @@ def transform_fn(model, request_body, input_content_type, output_content_type="a
         inference_kwargs = {}
 
     # Make predictions
-    if model.problem_type not in [REGRESSION, QUANTILE]:
+    if model.can_predict_proba:
         pred_proba = model.predict_proba(data, as_pandas=True, **inference_kwargs)
-        pred = get_pred_from_proba_df(pred_proba, problem_type=model.problem_type)
+        pred = model.predict_from_proba(pred_proba)
         pred_proba.columns = [str(c) + "_proba" for c in pred_proba.columns]
         pred.name = model.label
         prediction = pd.concat([pred, pred_proba], axis=1)

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
@@ -183,20 +183,12 @@ if __name__ == "__main__":
             predictions = predictor.predict(training_data, known_covariates=known_covariates)
             predictions = predictions.to_data_frame().reset_index()
         elif predictor_type == "tabular":
-            if "image_column" in ag_args:
-                raise NotImplementedError(
-                    "`fit_predict` does not support image columns yet. "
-                    "Use `fit` + `predict` for tabular data with image columns."
-                )
             assert args.test_dir is not None, "`test_data` channel is required for tabular fit_predict."
             test_data = prepare_data(get_input_path(args.test_dir), predictor_type, ag_args)
-            # Duplicated from tabular_serve.py:88-93 (tracked tech debt to de-dup later).
-            from autogluon.core.constants import QUANTILE, REGRESSION
-            from autogluon.core.utils import get_pred_from_proba_df
-
-            if predictor.problem_type not in [REGRESSION, QUANTILE]:
+            if predictor.can_predict_proba:
+                # Concat [pred, <class>_proba...] so the client can split it (see split_pred_and_pred_proba).
                 pred_proba = predictor.predict_proba(test_data, as_pandas=True)
-                pred = get_pred_from_proba_df(pred_proba, problem_type=predictor.problem_type)
+                pred = predictor.predict_from_proba(pred_proba)
                 pred_proba.columns = [str(c) + "_proba" for c in pred_proba.columns]
                 pred.name = predictor.label
                 predictions = pd.concat([pred, pred_proba], axis=1)

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
@@ -9,6 +9,7 @@ import shutil
 from pprint import pprint
 
 import boto3
+import pandas as pd
 import pickle
 
 from autogluon.common.loaders import load_pd
@@ -59,6 +60,7 @@ if __name__ == "__main__":
     parser.add_argument("--model-dir", type=str, default=get_env_if_present("SM_MODEL_DIR"))
     parser.add_argument("--n_gpus", type=str, default=get_env_if_present("SM_NUM_GPUS"))
     parser.add_argument("--train_dir", type=str, default=get_env_if_present("SM_CHANNEL_TRAIN_DATA"))
+    parser.add_argument("--test_dir", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TEST_DATA"))
     parser.add_argument("--tune_dir", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TUNING_DATA"))
     parser.add_argument(
         "--train_images", type=str, required=False, default=get_env_if_present("SM_CHANNEL_TRAIN_IMAGES")
@@ -176,16 +178,36 @@ if __name__ == "__main__":
             lb.to_csv(f"{args.output_data_dir}/leaderboard.csv")
 
     if ag_args.get("predict_after_fit", False):
-        if predictor_type != "timeseries":
-            raise NotImplementedError(
-                f"`fit_predict` is only supported for predictor_type='timeseries', got '{predictor_type}'."
-            )
         print("Running in-job prediction for fit_predict")
-        predictions = predictor.predict(training_data, known_covariates=known_covariates)
+        if predictor_type == "timeseries":
+            predictions = predictor.predict(training_data, known_covariates=known_covariates)
+            predictions = predictions.to_data_frame().reset_index()
+        elif predictor_type == "tabular":
+            if "image_column" in ag_args:
+                raise NotImplementedError(
+                    "`fit_predict` does not support image columns yet. "
+                    "Use `fit` + `predict` for tabular data with image columns."
+                )
+            assert args.test_dir is not None, "`test_data` channel is required for tabular fit_predict."
+            test_data = prepare_data(get_input_path(args.test_dir), predictor_type, ag_args)
+            # Duplicated from tabular_serve.py:88-93 (tracked tech debt to de-dup later).
+            from autogluon.core.constants import QUANTILE, REGRESSION
+            from autogluon.core.utils import get_pred_from_proba_df
+
+            if predictor.problem_type not in [REGRESSION, QUANTILE]:
+                pred_proba = predictor.predict_proba(test_data, as_pandas=True)
+                pred = get_pred_from_proba_df(pred_proba, problem_type=predictor.problem_type)
+                pred_proba.columns = [str(c) + "_proba" for c in pred_proba.columns]
+                pred.name = predictor.label
+                predictions = pd.concat([pred, pred_proba], axis=1)
+            else:
+                predictions = predictor.predict(test_data, as_pandas=True).to_frame()
+        else:
+            raise NotImplementedError(f"`fit_predict` is not supported for predictor_type='{predictor_type}'.")
         predictions_path = ag_args["predictions_path"]
         # Save locally then upload via boto3: s3fs/fsspec are not available in the training container.
         local_path = os.path.join(args.output_data_dir, os.path.basename(predictions_path))
-        save_pd.save(path=local_path, df=predictions.to_data_frame().reset_index())
+        save_pd.save(path=local_path, df=predictions)
         bucket, key = s3_path_to_bucket_prefix(predictions_path)
         boto3.client("s3").upload_file(local_path, bucket, key)
         print(f"Uploaded predictions to {predictions_path}")

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
@@ -100,6 +100,7 @@ if __name__ == "__main__":
     predictor_init_args = ag_args["predictor_init_args"]
     predictor_init_args["path"] = save_path
     predictor_fit_args = ag_args["predictor_fit_args"]
+    predict_after_fit = ag_args.get("predict_after_fit", False)
     valid_predictor_types = ["tabular", "multimodal", "timeseries"]
     assert predictor_type in valid_predictor_types, (
         f"predictor_type {predictor_type} not supported. Valid options are {valid_predictor_types}"
@@ -159,6 +160,9 @@ if __name__ == "__main__":
         if "known_covariates_names" not in predictor_init_args:
             predictor_init_args["known_covariates_names"] = list(known_covariates.columns)
 
+    if predict_after_fit and predictor_type == "tabular":
+        assert args.test_dir is not None, "`test_data` channel is required for tabular fit_predict."
+
     predictor = predictor_cls(**predictor_init_args).fit(training_data, tuning_data=tuning_data, **predictor_fit_args)
 
     # When use automm backend, predictor needs to be saved with standalone flag to avoid need of internet access when loading
@@ -177,13 +181,12 @@ if __name__ == "__main__":
             lb = predictor.leaderboard(silent=False)
             lb.to_csv(f"{args.output_data_dir}/leaderboard.csv")
 
-    if ag_args.get("predict_after_fit", False):
+    if predict_after_fit:
         print("Running in-job prediction for fit_predict")
         if predictor_type == "timeseries":
             predictions = predictor.predict(training_data, known_covariates=known_covariates)
             predictions = predictions.to_data_frame().reset_index()
         elif predictor_type == "tabular":
-            assert args.test_dir is not None, "`test_data` channel is required for tabular fit_predict."
             test_data = prepare_data(get_input_path(args.test_dir), predictor_type, ag_args)
             if predictor.can_predict_proba:
                 # Concat [pred, <class>_proba...] so the client can split it (see split_pred_and_pred_proba).

--- a/src/autogluon/cloud/utils/utils.py
+++ b/src/autogluon/cloud/utils/utils.py
@@ -84,7 +84,7 @@ def split_pred_and_pred_proba(prediction):
     pred_proba = None
     if len(prediction.columns) > 1:
         pred_proba = prediction.iloc[:, 1:]
-        pred_proba.columns = [[c.rsplit("_", 1)[0] for c in pred_proba.columns]]
+        pred_proba.columns = [c.removesuffix("_proba") for c in pred_proba.columns]
 
     return pred, pred_proba
 

--- a/tests/unittests/tabular/test_tabular.py
+++ b/tests/unittests/tabular/test_tabular.py
@@ -1,6 +1,9 @@
 import os
 import tempfile
 
+import pandas as pd
+import pytest
+
 from autogluon.cloud import TabularCloudPredictor
 from autogluon.common.features.feature_metadata import FeatureMetadata
 
@@ -70,3 +73,60 @@ def test_tabular_tabular_text_image(test_helper, framework_version):
         )
         models = local_predictor.model_names()
         assert "ImagePredictor" in models
+
+
+@pytest.mark.parametrize("problem", ["classification", "regression"])
+def test_tabular_fit_predict(test_helper, framework_version, problem):
+    """fit + in-job batch predict in a single SageMaker training job."""
+    import boto3
+
+    train_data = "tabular_train.csv"
+    test_data = "tabular_test.csv"
+    timestamp = test_helper.get_utc_timestamp_now()
+
+    bucket = "autogluon-cloud-ci"
+    predictions_key = f"test-tabular-fit-predict-{problem}/{framework_version}/{timestamp}/custom_predictions.csv"
+    predictions_path = f"s3://{bucket}/{predictions_key}"
+
+    # The shared tabular dataset has a categorical `class` target; `age` is a numeric column we reuse as a
+    # regression target so both problem types exercise the same path.
+    label = "class" if problem == "classification" else "age"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.chdir(temp_dir)
+        test_helper.prepare_data(train_data, test_data)
+        n_test_rows = len(pd.read_csv(test_data))
+
+        training_custom_image_uri = test_helper.get_custom_image_uri(framework_version, type="training", gpu=False)
+
+        cloud_predictor = TabularCloudPredictor(
+            cloud_output_path=f"s3://{bucket}/test-tabular-fit-predict-{problem}/{framework_version}/{timestamp}",
+            local_output_path=f"test_tabular_fit_predict_{problem}_cloud_predictor",
+        )
+
+        pred, pred_proba = cloud_predictor.fit_predict_proba(
+            train_data=train_data,
+            test_data=test_data,
+            predictor_init_args=dict(label=label),
+            predictor_fit_args=dict(time_limit=60),
+            include_predict=True,
+            framework_version=framework_version,
+            custom_image_uri=training_custom_image_uri,
+            predictions_path=predictions_path,
+        )
+
+        assert isinstance(pred, pd.Series)
+        assert len(pred) == n_test_rows
+        if problem == "classification":
+            assert isinstance(pred_proba, pd.DataFrame)
+            assert len(pred_proba) == n_test_rows
+        else:
+            # Regression: proba mirrors pred.
+            pd.testing.assert_series_equal(pred, pred_proba)
+
+        head = boto3.client("s3").head_object(Bucket=bucket, Key=predictions_key)
+        assert head["ContentLength"] > 0, "predictions file on S3 should not be empty"
+
+        info = cloud_predictor.info()
+        assert info["fit_job"]["name"] is not None
+        assert info["fit_job"]["status"] == "Completed"

--- a/tests/unittests/tabular/test_tabular.py
+++ b/tests/unittests/tabular/test_tabular.py
@@ -2,7 +2,6 @@ import os
 import tempfile
 
 import pandas as pd
-import pytest
 
 from autogluon.cloud import TabularCloudPredictor
 from autogluon.common.features.feature_metadata import FeatureMetadata
@@ -75,9 +74,13 @@ def test_tabular_tabular_text_image(test_helper, framework_version):
         assert "ImagePredictor" in models
 
 
-@pytest.mark.parametrize("problem", ["classification", "regression"])
-def test_tabular_fit_predict(test_helper, framework_version, problem):
-    """fit + in-job batch predict in a single SageMaker training job."""
+def test_tabular_fit_predict(test_helper, framework_version):
+    """fit + in-job batch predict in a single SageMaker training job.
+
+    Only the classification path is exercised end-to-end (it is the superset: it produces both the
+    prediction and the proba frame). The regression path — where proba mirrors pred — is covered by the
+    pure-unit tests in test_tabular_fit_predict.py, so it does not warrant a second SageMaker job.
+    """
     import boto3
 
     train_data = "tabular_train.csv"
@@ -85,12 +88,8 @@ def test_tabular_fit_predict(test_helper, framework_version, problem):
     timestamp = test_helper.get_utc_timestamp_now()
 
     bucket = "autogluon-cloud-ci"
-    predictions_key = f"test-tabular-fit-predict-{problem}/{framework_version}/{timestamp}/custom_predictions.csv"
+    predictions_key = f"test-tabular-fit-predict/{framework_version}/{timestamp}/custom_predictions.csv"
     predictions_path = f"s3://{bucket}/{predictions_key}"
-
-    # The shared tabular dataset has a categorical `class` target; `age` is a numeric column we reuse as a
-    # regression target so both problem types exercise the same path.
-    label = "class" if problem == "classification" else "age"
 
     with tempfile.TemporaryDirectory() as temp_dir:
         os.chdir(temp_dir)
@@ -100,14 +99,14 @@ def test_tabular_fit_predict(test_helper, framework_version, problem):
         training_custom_image_uri = test_helper.get_custom_image_uri(framework_version, type="training", gpu=False)
 
         cloud_predictor = TabularCloudPredictor(
-            cloud_output_path=f"s3://{bucket}/test-tabular-fit-predict-{problem}/{framework_version}/{timestamp}",
-            local_output_path=f"test_tabular_fit_predict_{problem}_cloud_predictor",
+            cloud_output_path=f"s3://{bucket}/test-tabular-fit-predict/{framework_version}/{timestamp}",
+            local_output_path="test_tabular_fit_predict_cloud_predictor",
         )
 
         pred, pred_proba = cloud_predictor.fit_predict_proba(
             train_data=train_data,
             test_data=test_data,
-            predictor_init_args=dict(label=label),
+            predictor_init_args=dict(label="class"),
             predictor_fit_args=dict(time_limit=60),
             include_predict=True,
             framework_version=framework_version,
@@ -117,12 +116,8 @@ def test_tabular_fit_predict(test_helper, framework_version, problem):
 
         assert isinstance(pred, pd.Series)
         assert len(pred) == n_test_rows
-        if problem == "classification":
-            assert isinstance(pred_proba, pd.DataFrame)
-            assert len(pred_proba) == n_test_rows
-        else:
-            # Regression: proba mirrors pred.
-            pd.testing.assert_series_equal(pred, pred_proba)
+        assert isinstance(pred_proba, pd.DataFrame)
+        assert len(pred_proba) == n_test_rows
 
         head = boto3.client("s3").head_object(Bucket=bucket, Key=predictions_key)
         assert head["ContentLength"] > 0, "predictions file on S3 should not be empty"

--- a/tests/unittests/tabular/test_tabular_fit_predict.py
+++ b/tests/unittests/tabular/test_tabular_fit_predict.py
@@ -51,7 +51,7 @@ def test_fit_predict_passes_predict_after_fit_and_test_data(cloud_predictor):
 
     backend_kwargs = fit.call_args.kwargs["backend_kwargs"]
     assert backend_kwargs["extra_ag_args"]["predict_after_fit"] is True
-    assert backend_kwargs["test_data"] is test_data
+    assert fit.call_args.kwargs["test_data"] is test_data
     assert "predictions_path" not in backend_kwargs["extra_ag_args"]
 
 
@@ -167,16 +167,6 @@ def backend():
     return backend
 
 
-def test_backend_fit_rejects_test_data_without_predict_after_fit(backend):
-    with pytest.raises(ValueError, match="predict_after_fit=True"):
-        backend.fit(
-            predictor_init_args={"label": "y"},
-            predictor_fit_args={},
-            data_channels={"train_data": pd.DataFrame({"x": [1], "y": [0]})},
-            test_data=pd.DataFrame({"x": [1]}),
-        )
-
-
 def test_backend_fit_rejects_test_data_missing_feature_columns(backend):
     train = pd.DataFrame({"x": [1, 2], "z": [3, 4], "y": [0, 1]})
     test = pd.DataFrame({"x": [5]})  # missing feature column `z`
@@ -184,13 +174,11 @@ def test_backend_fit_rejects_test_data_missing_feature_columns(backend):
         backend.fit(
             predictor_init_args={"label": "y"},
             predictor_fit_args={},
-            data_channels={"train_data": train},
-            test_data=test,
-            extra_ag_args={"predict_after_fit": True},
+            data_channels={"train_data": train, "test_data": test},
         )
 
 
-def test_backend_fit_injects_test_data_channel(backend):
+def test_backend_fit_forwards_test_data_channel(backend):
     train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
     test = pd.DataFrame({"x": [5, 6]})
 
@@ -198,23 +186,12 @@ def test_backend_fit_injects_test_data_channel(backend):
         backend.fit(
             predictor_init_args={"label": "y"},
             predictor_fit_args={},
-            data_channels={"train_data": train},
-            test_data=test,
-            extra_ag_args={"predict_after_fit": True},
+            data_channels={"train_data": train, "test_data": test},
         )
 
     forwarded_channels = super_fit.call_args.kwargs["data_channels"]
     assert "test_data" in forwarded_channels
     pd.testing.assert_frame_equal(forwarded_channels["test_data"], test)
-
-
-def test_parse_backend_fit_kwargs_extracts_test_data(backend):
-    """`test_data` must survive backend_kwargs parsing so it reaches `fit`."""
-    parsed = backend.parse_backend_fit_kwargs(
-        {"test_data": pd.DataFrame({"x": [1]}), "extra_ag_args": {"predict_after_fit": True}}
-    )
-    assert isinstance(parsed["test_data"], pd.DataFrame)
-    assert parsed["extra_ag_args"] == {"predict_after_fit": True}
 
 
 def test_backend_fit_test_data_allows_label_column_absent(backend):
@@ -226,7 +203,5 @@ def test_backend_fit_test_data_allows_label_column_absent(backend):
         backend.fit(
             predictor_init_args={"label": "y"},
             predictor_fit_args={},
-            data_channels={"train_data": train},
-            test_data=test,
-            extra_ag_args={"predict_after_fit": True},
+            data_channels={"train_data": train, "test_data": test},
         )

--- a/tests/unittests/tabular/test_tabular_fit_predict.py
+++ b/tests/unittests/tabular/test_tabular_fit_predict.py
@@ -1,0 +1,232 @@
+"""Pure-unit tests for the ``fit_predict`` / ``fit_predict_proba`` wiring on TabularCloudPredictor.
+
+These mock out the SageMaker backend entirely (no AWS) and assert the argument plumbing, return-shape
+selection, and client-side validation.
+"""
+
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+from autogluon.cloud import TabularCloudPredictor
+from autogluon.cloud.backend.tabular_sagemaker_backend import TabularSagemakerBackend
+
+
+@pytest.fixture
+def cloud_predictor():
+    """A TabularCloudPredictor whose backend is a MagicMock — no AWS interaction."""
+    with mock.patch.object(TabularCloudPredictor, "__init__", lambda self: None):
+        predictor = TabularCloudPredictor()
+    predictor.backend = mock.MagicMock()
+    return predictor
+
+
+# Pred/proba frame as written by the training container: first column is the prediction,
+# remaining columns are `<class>_proba`.
+def _classification_frame():
+    return pd.DataFrame(
+        {
+            "class": ["a", "b"],
+            "a_proba": [0.7, 0.3],
+            "b_proba": [0.3, 0.7],
+        }
+    )
+
+
+def _regression_frame():
+    return pd.DataFrame({"target": [1.5, 2.5]})
+
+
+def test_fit_predict_passes_predict_after_fit_and_test_data(cloud_predictor):
+    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
+    test_data = pd.DataFrame({"x": [1, 2]})
+
+    with mock.patch.object(cloud_predictor, "fit") as fit:
+        cloud_predictor.fit_predict(
+            train_data="train.csv",
+            test_data=test_data,
+            predictor_init_args={"label": "class"},
+        )
+
+    backend_kwargs = fit.call_args.kwargs["backend_kwargs"]
+    assert backend_kwargs["extra_ag_args"]["predict_after_fit"] is True
+    assert backend_kwargs["test_data"] is test_data
+    assert "predictions_path" not in backend_kwargs["extra_ag_args"]
+
+
+def test_fit_predict_forwards_predictions_path(cloud_predictor):
+    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
+
+    with mock.patch.object(cloud_predictor, "fit") as fit:
+        cloud_predictor.fit_predict(
+            train_data="train.csv",
+            test_data="test.csv",
+            predictor_init_args={"label": "class"},
+            predictions_path="s3://bucket/key/predictions.csv",
+        )
+
+    extra_ag_args = fit.call_args.kwargs["backend_kwargs"]["extra_ag_args"]
+    assert extra_ag_args["predictions_path"] == "s3://bucket/key/predictions.csv"
+
+
+def test_fit_predict_returns_prediction_series(cloud_predictor):
+    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
+
+    with mock.patch.object(cloud_predictor, "fit"):
+        pred = cloud_predictor.fit_predict(
+            train_data="train.csv",
+            test_data="test.csv",
+            predictor_init_args={"label": "class"},
+        )
+
+    assert isinstance(pred, pd.Series)
+    assert pred.tolist() == ["a", "b"]
+
+
+def test_fit_predict_wait_false_returns_none(cloud_predictor):
+    with mock.patch.object(cloud_predictor, "fit"):
+        result = cloud_predictor.fit_predict(
+            train_data="train.csv",
+            test_data="test.csv",
+            predictor_init_args={"label": "class"},
+            wait=False,
+        )
+
+    assert result is None
+    cloud_predictor.backend.get_fit_predict_results.assert_not_called()
+
+
+def test_fit_predict_proba_include_predict_true_returns_pred_and_proba(cloud_predictor):
+    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
+
+    with mock.patch.object(cloud_predictor, "fit"):
+        result = cloud_predictor.fit_predict_proba(
+            train_data="train.csv",
+            test_data="test.csv",
+            predictor_init_args={"label": "class"},
+            include_predict=True,
+        )
+
+    assert isinstance(result, tuple)
+    pred, proba = result
+    assert pred.tolist() == ["a", "b"]
+    assert isinstance(proba, pd.DataFrame)
+    assert proba.shape == (2, 2)
+
+
+def test_fit_predict_proba_include_predict_false_returns_only_proba(cloud_predictor):
+    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
+
+    with mock.patch.object(cloud_predictor, "fit"):
+        result = cloud_predictor.fit_predict_proba(
+            train_data="train.csv",
+            test_data="test.csv",
+            predictor_init_args={"label": "class"},
+            include_predict=False,
+        )
+
+    assert isinstance(result, pd.DataFrame)
+
+
+def test_fit_predict_proba_regression_proba_equals_pred(cloud_predictor):
+    cloud_predictor.backend.get_fit_predict_results.return_value = _regression_frame()
+
+    with mock.patch.object(cloud_predictor, "fit"):
+        pred, proba = cloud_predictor.fit_predict_proba(
+            train_data="train.csv",
+            test_data="test.csv",
+            predictor_init_args={"label": "target"},
+        )
+
+    assert pred.tolist() == [1.5, 2.5]
+    pd.testing.assert_series_equal(pred, proba)
+
+
+def test_fit_predict_proba_wait_false_returns_none(cloud_predictor):
+    with mock.patch.object(cloud_predictor, "fit"):
+        result = cloud_predictor.fit_predict_proba(
+            train_data="train.csv",
+            test_data="test.csv",
+            predictor_init_args={"label": "class"},
+            wait=False,
+        )
+
+    assert result is None
+    cloud_predictor.backend.get_fit_predict_results.assert_not_called()
+
+
+# ----------------------------------------------------------------- backend-level validation
+
+
+@pytest.fixture
+def backend():
+    """A TabularSagemakerBackend with the base ``fit`` and AWS init stubbed out."""
+    with mock.patch.object(TabularSagemakerBackend, "__init__", lambda self: None):
+        backend = TabularSagemakerBackend()
+    return backend
+
+
+def test_backend_fit_rejects_test_data_without_predict_after_fit(backend):
+    with pytest.raises(ValueError, match="predict_after_fit=True"):
+        backend.fit(
+            predictor_init_args={"label": "y"},
+            predictor_fit_args={},
+            data_channels={"train_data": pd.DataFrame({"x": [1], "y": [0]})},
+            test_data=pd.DataFrame({"x": [1]}),
+        )
+
+
+def test_backend_fit_rejects_test_data_missing_feature_columns(backend):
+    train = pd.DataFrame({"x": [1, 2], "z": [3, 4], "y": [0, 1]})
+    test = pd.DataFrame({"x": [5]})  # missing feature column `z`
+    with pytest.raises(ValueError, match="missing feature columns"):
+        backend.fit(
+            predictor_init_args={"label": "y"},
+            predictor_fit_args={},
+            data_channels={"train_data": train},
+            test_data=test,
+            extra_ag_args={"predict_after_fit": True},
+        )
+
+
+def test_backend_fit_injects_test_data_channel(backend):
+    train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
+    test = pd.DataFrame({"x": [5, 6]})
+
+    with mock.patch.object(TabularSagemakerBackend.__bases__[0], "fit") as super_fit:
+        backend.fit(
+            predictor_init_args={"label": "y"},
+            predictor_fit_args={},
+            data_channels={"train_data": train},
+            test_data=test,
+            extra_ag_args={"predict_after_fit": True},
+        )
+
+    forwarded_channels = super_fit.call_args.kwargs["data_channels"]
+    assert "test_data" in forwarded_channels
+    pd.testing.assert_frame_equal(forwarded_channels["test_data"], test)
+
+
+def test_parse_backend_fit_kwargs_extracts_test_data(backend):
+    """`test_data` must survive backend_kwargs parsing so it reaches `fit`."""
+    parsed = backend.parse_backend_fit_kwargs(
+        {"test_data": pd.DataFrame({"x": [1]}), "extra_ag_args": {"predict_after_fit": True}}
+    )
+    assert isinstance(parsed["test_data"], pd.DataFrame)
+    assert parsed["extra_ag_args"] == {"predict_after_fit": True}
+
+
+def test_backend_fit_test_data_allows_label_column_absent(backend):
+    """test_data need not contain the label column, only the feature columns."""
+    train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
+    test = pd.DataFrame({"x": [5, 6]})  # no `y`, that's fine
+
+    with mock.patch.object(TabularSagemakerBackend.__bases__[0], "fit"):
+        backend.fit(
+            predictor_init_args={"label": "y"},
+            predictor_fit_args={},
+            data_channels={"train_data": train},
+            test_data=test,
+            extra_ag_args={"predict_after_fit": True},
+        )

--- a/tests/unittests/tabular/test_tabular_fit_predict.py
+++ b/tests/unittests/tabular/test_tabular_fit_predict.py
@@ -10,153 +10,69 @@ import pandas as pd
 import pytest
 
 from autogluon.cloud import TabularCloudPredictor
+from autogluon.cloud.backend.sagemaker_backend import SagemakerBackend
 from autogluon.cloud.backend.tabular_sagemaker_backend import TabularSagemakerBackend
+
+# Pred/proba frame as written by the training container: first column is the prediction,
+# remaining columns are `<class>_proba`.
+CLASSIFICATION_FRAME = pd.DataFrame({"class": ["a", "b"], "a_proba": [0.7, 0.3], "b_proba": [0.3, 0.7]})
+REGRESSION_FRAME = pd.DataFrame({"target": [1.5, 2.5]})
+
+DEFAULT_ARGS = dict(train_data="train.csv", test_data="test.csv", predictor_init_args={"label": "class"})
 
 
 @pytest.fixture
 def cloud_predictor():
-    """A TabularCloudPredictor whose backend is a MagicMock — no AWS interaction."""
+    """A TabularCloudPredictor with `fit` and the backend mocked out — no AWS interaction."""
     with mock.patch.object(TabularCloudPredictor, "__init__", lambda self: None):
         predictor = TabularCloudPredictor()
+    predictor.fit = mock.MagicMock()
     predictor.backend = mock.MagicMock()
+    predictor.backend.get_fit_predict_results.return_value = CLASSIFICATION_FRAME
     return predictor
 
 
-# Pred/proba frame as written by the training container: first column is the prediction,
-# remaining columns are `<class>_proba`.
-def _classification_frame():
-    return pd.DataFrame(
-        {
-            "class": ["a", "b"],
-            "a_proba": [0.7, 0.3],
-            "b_proba": [0.3, 0.7],
-        }
-    )
+def test_when_fit_predict_then_launches_predict_job_and_returns_prediction_series(cloud_predictor):
+    pred = cloud_predictor.fit_predict(**DEFAULT_ARGS)
+    extra_ag_args = cloud_predictor.fit.call_args.kwargs["backend_kwargs"]["extra_ag_args"]
 
-
-def _regression_frame():
-    return pd.DataFrame({"target": [1.5, 2.5]})
-
-
-def test_fit_predict_passes_predict_after_fit_and_test_data(cloud_predictor):
-    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
-    test_data = pd.DataFrame({"x": [1, 2]})
-
-    with mock.patch.object(cloud_predictor, "fit") as fit:
-        cloud_predictor.fit_predict(
-            train_data="train.csv",
-            test_data=test_data,
-            predictor_init_args={"label": "class"},
-        )
-
-    backend_kwargs = fit.call_args.kwargs["backend_kwargs"]
-    assert backend_kwargs["extra_ag_args"]["predict_after_fit"] is True
-    assert fit.call_args.kwargs["test_data"] is test_data
-    assert "predictions_path" not in backend_kwargs["extra_ag_args"]
-
-
-def test_fit_predict_forwards_predictions_path(cloud_predictor):
-    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
-
-    with mock.patch.object(cloud_predictor, "fit") as fit:
-        cloud_predictor.fit_predict(
-            train_data="train.csv",
-            test_data="test.csv",
-            predictor_init_args={"label": "class"},
-            predictions_path="s3://bucket/key/predictions.csv",
-        )
-
-    extra_ag_args = fit.call_args.kwargs["backend_kwargs"]["extra_ag_args"]
-    assert extra_ag_args["predictions_path"] == "s3://bucket/key/predictions.csv"
-
-
-def test_fit_predict_returns_prediction_series(cloud_predictor):
-    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
-
-    with mock.patch.object(cloud_predictor, "fit"):
-        pred = cloud_predictor.fit_predict(
-            train_data="train.csv",
-            test_data="test.csv",
-            predictor_init_args={"label": "class"},
-        )
-
+    assert extra_ag_args["predict_after_fit"] is True
+    assert "predictions_path" not in extra_ag_args  # not passed -> backend fills in a default
     assert isinstance(pred, pd.Series)
     assert pred.tolist() == ["a", "b"]
 
 
-def test_fit_predict_wait_false_returns_none(cloud_predictor):
-    with mock.patch.object(cloud_predictor, "fit"):
-        result = cloud_predictor.fit_predict(
-            train_data="train.csv",
-            test_data="test.csv",
-            predictor_init_args={"label": "class"},
-            wait=False,
-        )
-
-    assert result is None
-    cloud_predictor.backend.get_fit_predict_results.assert_not_called()
+def test_when_predictions_path_given_then_forwarded_to_backend(cloud_predictor):
+    cloud_predictor.fit_predict(**DEFAULT_ARGS, predictions_path="s3://bucket/key/predictions.csv")
+    extra_ag_args = cloud_predictor.fit.call_args.kwargs["backend_kwargs"]["extra_ag_args"]
+    assert extra_ag_args["predictions_path"] == "s3://bucket/key/predictions.csv"
 
 
-def test_fit_predict_proba_include_predict_true_returns_pred_and_proba(cloud_predictor):
-    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
-
-    with mock.patch.object(cloud_predictor, "fit"):
-        result = cloud_predictor.fit_predict_proba(
-            train_data="train.csv",
-            test_data="test.csv",
-            predictor_init_args={"label": "class"},
-            include_predict=True,
-        )
-
-    assert isinstance(result, tuple)
-    pred, proba = result
+def test_when_fit_predict_proba_then_returns_prediction_and_flat_proba_columns(cloud_predictor):
+    pred, proba = cloud_predictor.fit_predict_proba(**DEFAULT_ARGS, include_predict=True)
     assert pred.tolist() == ["a", "b"]
-    assert isinstance(proba, pd.DataFrame)
-    assert proba.shape == (2, 2)
     # Columns must be flat class labels (matching predict_proba), not the `_proba`-suffixed or MultiIndex
     # form produced by the training container.
     assert proba.columns.tolist() == ["a", "b"]
     assert proba["a"].tolist() == [0.7, 0.3]
 
 
-def test_fit_predict_proba_include_predict_false_returns_only_proba(cloud_predictor):
-    cloud_predictor.backend.get_fit_predict_results.return_value = _classification_frame()
-
-    with mock.patch.object(cloud_predictor, "fit"):
-        result = cloud_predictor.fit_predict_proba(
-            train_data="train.csv",
-            test_data="test.csv",
-            predictor_init_args={"label": "class"},
-            include_predict=False,
-        )
-
-    assert isinstance(result, pd.DataFrame)
+def test_when_include_predict_false_then_returns_only_proba(cloud_predictor):
+    proba = cloud_predictor.fit_predict_proba(**DEFAULT_ARGS, include_predict=False)
+    assert isinstance(proba, pd.DataFrame)
+    assert proba.columns.tolist() == ["a", "b"]
 
 
-def test_fit_predict_proba_regression_proba_equals_pred(cloud_predictor):
-    cloud_predictor.backend.get_fit_predict_results.return_value = _regression_frame()
-
-    with mock.patch.object(cloud_predictor, "fit"):
-        pred, proba = cloud_predictor.fit_predict_proba(
-            train_data="train.csv",
-            test_data="test.csv",
-            predictor_init_args={"label": "target"},
-        )
-
+def test_when_regression_then_proba_equals_pred(cloud_predictor):
+    cloud_predictor.backend.get_fit_predict_results.return_value = REGRESSION_FRAME
+    pred, proba = cloud_predictor.fit_predict_proba(**{**DEFAULT_ARGS, "predictor_init_args": {"label": "target"}})
     assert pred.tolist() == [1.5, 2.5]
     pd.testing.assert_series_equal(pred, proba)
 
 
-def test_fit_predict_proba_wait_false_returns_none(cloud_predictor):
-    with mock.patch.object(cloud_predictor, "fit"):
-        result = cloud_predictor.fit_predict_proba(
-            train_data="train.csv",
-            test_data="test.csv",
-            predictor_init_args={"label": "class"},
-            wait=False,
-        )
-
-    assert result is None
+def test_when_wait_false_then_returns_none_without_fetching_results(cloud_predictor):
+    assert cloud_predictor.fit_predict(**DEFAULT_ARGS, wait=False) is None
+    assert cloud_predictor.fit_predict_proba(**DEFAULT_ARGS, wait=False) is None
     cloud_predictor.backend.get_fit_predict_results.assert_not_called()
 
 
@@ -165,67 +81,38 @@ def test_fit_predict_proba_wait_false_returns_none(cloud_predictor):
 
 @pytest.fixture
 def backend():
-    """A TabularSagemakerBackend with the base ``fit`` and AWS init stubbed out."""
+    """A TabularSagemakerBackend with AWS init and the base `fit` stubbed out."""
     with mock.patch.object(TabularSagemakerBackend, "__init__", lambda self: None):
         backend = TabularSagemakerBackend()
-    return backend
+    with mock.patch.object(SagemakerBackend, "fit"):
+        yield backend
 
 
-def test_backend_fit_rejects_test_data_missing_feature_columns(backend):
+def _backend_fit(backend, train, test=None, label="y"):
+    data_channels = {"train_data": train} if test is None else {"train_data": train, "test_data": test}
+    backend.fit(predictor_init_args={"label": label}, predictor_fit_args={}, data_channels=data_channels)
+
+
+def test_when_test_data_omits_label_column_then_validation_passes(backend):
+    train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
+    test = pd.DataFrame({"x": [5, 6]})  # no label column — only feature columns are required
+    _backend_fit(backend, train, test)  # does not raise
+
+
+def test_when_test_data_missing_feature_columns_then_raises(backend):
     train = pd.DataFrame({"x": [1, 2], "z": [3, 4], "y": [0, 1]})
     test = pd.DataFrame({"x": [5]})  # missing feature column `z`
     with pytest.raises(ValueError, match="missing feature columns"):
-        backend.fit(
-            predictor_init_args={"label": "y"},
-            predictor_fit_args={},
-            data_channels={"train_data": train, "test_data": test},
-        )
+        _backend_fit(backend, train, test)
 
 
-def test_backend_fit_forwards_test_data_channel(backend):
-    train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
-    test = pd.DataFrame({"x": [5, 6]})
-
-    with mock.patch.object(TabularSagemakerBackend.__bases__[0], "fit") as super_fit:
-        backend.fit(
-            predictor_init_args={"label": "y"},
-            predictor_fit_args={},
-            data_channels={"train_data": train, "test_data": test},
-        )
-
-    forwarded_channels = super_fit.call_args.kwargs["data_channels"]
-    assert "test_data" in forwarded_channels
-    pd.testing.assert_frame_equal(forwarded_channels["test_data"], test)
-
-
-def test_backend_fit_test_data_allows_label_column_absent(backend):
-    """test_data need not contain the label column, only the feature columns."""
-    train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
-    test = pd.DataFrame({"x": [5, 6]})  # no `y`, that's fine
-
-    with mock.patch.object(TabularSagemakerBackend.__bases__[0], "fit"):
-        backend.fit(
-            predictor_init_args={"label": "y"},
-            predictor_fit_args={},
-            data_channels={"train_data": train, "test_data": test},
-        )
-
-
-def test_backend_fit_rejects_missing_label_in_init_args(backend):
+def test_when_label_missing_from_init_args_then_raises(backend):
     train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
     with pytest.raises(ValueError, match="must contain `label`"):
-        backend.fit(
-            predictor_init_args={},
-            predictor_fit_args={},
-            data_channels={"train_data": train},
-        )
+        backend.fit(predictor_init_args={}, predictor_fit_args={}, data_channels={"train_data": train})
 
 
-def test_backend_fit_rejects_label_absent_from_train_data(backend):
+def test_when_label_absent_from_train_data_then_raises(backend):
     train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
     with pytest.raises(ValueError, match="not present in `train_data`"):
-        backend.fit(
-            predictor_init_args={"label": "nonexistent"},
-            predictor_fit_args={},
-            data_channels={"train_data": train},
-        )
+        _backend_fit(backend, train, label="nonexistent")

--- a/tests/unittests/tabular/test_tabular_fit_predict.py
+++ b/tests/unittests/tabular/test_tabular_fit_predict.py
@@ -113,6 +113,10 @@ def test_fit_predict_proba_include_predict_true_returns_pred_and_proba(cloud_pre
     assert pred.tolist() == ["a", "b"]
     assert isinstance(proba, pd.DataFrame)
     assert proba.shape == (2, 2)
+    # Columns must be flat class labels (matching predict_proba), not the `_proba`-suffixed or MultiIndex
+    # form produced by the training container.
+    assert proba.columns.tolist() == ["a", "b"]
+    assert proba["a"].tolist() == [0.7, 0.3]
 
 
 def test_fit_predict_proba_include_predict_false_returns_only_proba(cloud_predictor):
@@ -204,4 +208,24 @@ def test_backend_fit_test_data_allows_label_column_absent(backend):
             predictor_init_args={"label": "y"},
             predictor_fit_args={},
             data_channels={"train_data": train, "test_data": test},
+        )
+
+
+def test_backend_fit_rejects_missing_label_in_init_args(backend):
+    train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
+    with pytest.raises(ValueError, match="must contain `label`"):
+        backend.fit(
+            predictor_init_args={},
+            predictor_fit_args={},
+            data_channels={"train_data": train},
+        )
+
+
+def test_backend_fit_rejects_label_absent_from_train_data(backend):
+    train = pd.DataFrame({"x": [1, 2], "y": [0, 1]})
+    with pytest.raises(ValueError, match="not present in `train_data`"):
+        backend.fit(
+            predictor_init_args={"label": "nonexistent"},
+            predictor_fit_args={},
+            data_channels={"train_data": train},
         )


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add `fit_predict` / `fit_predict_proba` to `TabularCloudPredictor`, fitting a `TabularPredictor` and running batch prediction on `test_data` inside a **single** SageMaker training job.

```python
predictor = TabularCloudPredictor(cloud_output_path="s3://bucket/output")

# predictions only
pred = predictor.fit_predict(
    train_data="train.csv",
    test_data="test.csv",
    predictor_init_args=dict(label="class"),
)

# predictions + class probabilities
pred, proba = predictor.fit_predict_proba(
    train_data="train.csv",
    test_data="test.csv",
    predictor_init_args=dict(label="class"),
)
```

**Breaking changes**
- `split_pred_and_pred_proba` now returns flat string columns for `predict_proba`. This affects the already-shipped endpoint `predict_proba` / batch `predict_proba` return shape (columns were previously a MultiIndex). The old shape was effectively a bug — columns didn't match the local predictor — but anyone working around the `MultiIndex` will be affected.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
