### PR TITLE
Clean up user-facing docstrings

### DIFF
--- a/src/autogluon/cloud/backend/backend_factory.py
+++ b/src/autogluon/cloud/backend/backend_factory.py
@@ -1,9 +1,13 @@
+import logging
+
 from .backend import Backend
 from .constant import RAY_AWS, TABULAR_RAY_AWS
 from .multimodal_sagemaker_backend import MultiModalSagemakerBackend
 from .sagemaker_backend import SagemakerBackend
 from .tabular_sagemaker_backend import TabularSagemakerBackend
 from .timeseries_sagemaker_backend import TimeSeriesSagemakerBackend
+
+logger = logging.getLogger(__name__)
 
 
 class BackendFactory:
@@ -20,6 +24,10 @@ class BackendFactory:
         if backend in BackendFactory._SAGEMAKER_BACKENDS:
             return BackendFactory._SAGEMAKER_BACKENDS[backend]
         if backend in BackendFactory._RAY_BACKEND_NAMES:
+            logger.warning(
+                f"The '{backend}' backend is experimental and not fully supported. Use at your own risk; "
+                "for production workloads prefer the 'sagemaker' backend."
+            )
             try:
                 from .ray_aws_backend import RayAWSBackend, TabularRayAWSBackend
             except ImportError as e:

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -181,13 +181,7 @@ class CloudPredictor(ABC):
         **kwargs,
     ) -> CloudPredictor:
         """
-        Fit the predictor with the backend.
-
-        Equivalent to running
-
-            TabularPredictor(**predictor_init_args).fit(train_data=train_data, **predictor_fit_args)
-
-        as a remote SageMaker training job, with the fitted predictor saved to S3.
+        Fit the predictor in a SageMaker training job.
 
         Parameters
         ----------

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -185,10 +185,9 @@ class CloudPredictor(ABC):
 
         Equivalent to running
 
-            predictor_cls(**predictor_init_args).fit(train_data=train_data, **predictor_fit_args)
+            TabularPredictor(**predictor_init_args).fit(train_data=train_data, **predictor_fit_args)
 
-        as a remote SageMaker training job, with the fitted predictor saved to S3. ``predictor_cls`` is the
-        underlying AutoGluon predictor (e.g. ``TabularPredictor``, ``MultiModalPredictor``).
+        as a remote SageMaker training job, with the fitted predictor saved to S3.
 
         Parameters
         ----------

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -183,6 +183,13 @@ class CloudPredictor(ABC):
         """
         Fit the predictor with the backend.
 
+        Equivalent to running
+
+            predictor_cls(**predictor_init_args).fit(train_data=train_data, **predictor_fit_args)
+
+        as a remote SageMaker training job, with the fitted predictor saved to S3. ``predictor_cls`` is the
+        underlying AutoGluon predictor (e.g. ``TabularPredictor``, ``MultiModalPredictor``).
+
         Parameters
         ----------
         train_data: Union[str, pathlib.Path, pd.DataFrame]

--- a/src/autogluon/cloud/predictor/cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/cloud_predictor.py
@@ -209,11 +209,11 @@ class CloudPredictor(ABC):
             If None, CloudPredictor will create one with prefix ag-cloudpredictor
         instance_type: str, default = 'ml.m5.2xlarge'
             Instance type the predictor will be trained on with SageMaker.
-        instance_count: int, default = 1
-            Number of instance used to fit the predictor.
-            If not specified, will decide by the backend
-        volumes_size: int, default = 256
-            Size in GB of the EBS volume to use for storing input data during training (default: 256).
+        instance_count: Union[int, str], default = "auto"
+            Number of instances used to fit the predictor.
+            If "auto", the backend decides the instance count.
+        volume_size: int, default = 256
+            Size in GB of the EBS volume to use for storing input data during training.
             Must be large enough to store training data if File Mode is used (which is the default).
         timeout: int, default = 24*60*60
             Timeout in seconds for training. This timeout doesn't include time for pre-processing or launching up the training job.
@@ -230,19 +230,6 @@ class CloudPredictor(ABC):
                 2. fit_kwargs
                     Any extra arguments needed to pass to fit.
                     Please refer to https://sagemaker.readthedocs.io/en/v2/api/training/estimators.html#sagemaker.estimator.Estimator.fit for all options
-            For RayAWS backend, valid keys are:
-                1. custom_config: Optional[Union[str, Dict[str, Any]]] = None,
-                    The custom cluster configuration.
-                    Please refer to https://docs.ray.io/en/latest/cluster/vms/references/ray-cluster-configuration.html#cluster-yaml-configuration-options for details
-                2. cluster_name: Optional[str] = None,
-                    The name of the ephemeral cluster being created.
-                    If not specified, will be auto-generated with format f"ag_ray_aws_default_{timestamp}"
-                3. initialization_commands: Optional[List[str]], default = None
-                    The initialization commands of the ray cluster.
-                    If not specified, will contain a default ECR login command to be able to pull AG DLC image, i.e.
-                        - aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
-                    To learn more about initialization_commands,
-                        https://docs.ray.io/en/latest/cluster/vms/references/ray-cluster-configuration.html#initialization-commands
         Returns
         -------
         `CloudPredictor` object. Returns self.
@@ -431,9 +418,9 @@ class CloudPredictor(ABC):
             Custom image to use to deploy endpoint with.
             If not specified, with use official DLC image:
             https://github.com/aws/deep-learning-containers/blob/master/available_images.md#autogluon-inference-containers
-        volumes_size: int, default = None
-            Size in GB of the EBS volume to use for the endpoint (default: None).
-            SageMaker GPU instance endpoint currently doesn't support specifying volumes_size. Will ignore in such cases.
+        volume_size: int, default = None
+            Size in GB of the EBS volume to use for the endpoint.
+            SageMaker GPU instance endpoint currently doesn't support specifying volume_size. Will ignore in such cases.
         wait: Bool, default = True,
             Whether to wait for the endpoint to be deployed.
             To be noticed, the function won't return immediately because there are some preparations needed prior deployment.

--- a/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
@@ -56,13 +56,7 @@ class TimeSeriesCloudPredictor(CloudPredictor):
         known_covariates: Optional[Union[str, Path, pd.DataFrame]] = None,
     ) -> TimeSeriesCloudPredictor:
         """
-        Fit the predictor with SageMaker.
-
-        Equivalent to running
-
-            TimeSeriesPredictor(**predictor_init_args).fit(train_data=train_data, **predictor_fit_args)
-
-        as a remote SageMaker training job, with the fitted predictor saved to S3.
+        Fit the predictor in a SageMaker training job.
 
         Parameters
         ----------
@@ -350,9 +344,6 @@ class TimeSeriesCloudPredictor(CloudPredictor):
     ) -> Optional[pd.DataFrame]:
         """
         Fit and predict in a single SageMaker training job.
-
-        This is useful for foundation-model forecasting workflows (e.g. Chronos-2) where "fit" is essentially loading
-        a pretrained model. Running fit and predict in the same job avoids the SageMaker startup overhead twice.
 
         Predictions are generated inside the training container against ``train_data`` (the standard time-series
         forecasting flow where the last ``prediction_length`` steps of each series are forecast) and written

--- a/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
@@ -57,8 +57,6 @@ class TimeSeriesCloudPredictor(CloudPredictor):
     ) -> TimeSeriesCloudPredictor:
         """
         Fit the predictor with SageMaker.
-        This function will first upload necessary config and train data to s3 bucket.
-        Then launch a SageMaker training job with the AutoGluon training container.
 
         Parameters
         ----------
@@ -78,6 +76,9 @@ class TimeSeriesCloudPredictor(CloudPredictor):
             explicit arguments above.
         tuning_data: Optional[Union[str, pathlib.Path, pd.DataFrame]], default = None
             Optional tuning data in long format, as a DataFrame or local/S3 path to a data file.
+        known_covariates: Optional[Union[str, pathlib.Path, pd.DataFrame]], default = None
+            Values of the known covariates. Must be provided if ``known_covariates_names`` was specified
+            in ``predictor_init_args``.
         static_features: Optional[Union[str, pathlib.Path, pd.DataFrame]], default = None
             Static (time-independent) features describing each individual time series.
         id_column: str, default = "item_id"
@@ -95,10 +96,12 @@ class TimeSeriesCloudPredictor(CloudPredictor):
         instance_type: str, default = 'ml.m5.2xlarge'
             Instance type the predictor will be trained on with SageMaker.
         instance_count: int, default = 1
-            Number of instance used to fit the predictor.
-        volumes_size: int, default = 30
-            Size in GB of the EBS volume to use for storing input data during training (default: 30).
+            Number of instances used to fit the predictor.
+        volume_size: int, default = 100
+            Size in GB of the EBS volume to use for storing input data during training.
             Must be large enough to store training data if File Mode is used (which is the default).
+        custom_image_uri: Optional[str], default = None
+            Custom container image URI. If set, ``framework_version`` is ignored.
         wait: bool, default = True
             Whether the call should wait until the job completes
             To be noticed, the function won't return immediately because there are some preparations needed prior fit.
@@ -236,8 +239,6 @@ class TimeSeriesCloudPredictor(CloudPredictor):
         When minimizing latency isn't a concern, then the batch transform functionality may be easier, more scalable, and more appropriate.
         If you want to minimize latency, use `predict_real_time()` instead.
         To learn more: https://docs.aws.amazon.com/sagemaker/latest/dg/batch-transform.html
-        This method would first create a AutoGluonSagemakerInferenceModel with the trained predictor,
-        then create a transformer with it, and call transform in the end.
 
         ``data`` must use the same ``id_column`` / ``timestamp_column`` names that were passed to ``fit()``.
 
@@ -389,14 +390,14 @@ class TimeSeriesCloudPredictor(CloudPredictor):
             Custom container image URI. If set, ``framework_version`` is ignored.
         wait: bool, default = True
             Whether the call should wait until the job completes.
-        backend_kwargs: Optional[dict], default = None
-            Backend-specific arguments. Same keys as ``fit()``.
         predictions_path: Optional[str]
             S3 URL where predictions will be written by the training container (e.g.
             ``s3://my-bucket/runs/2024-05-01/predictions.csv``). The container's SageMaker execution role must have
             ``s3:PutObject`` permission for this location. Defaults to
             ``{cloud_output_path}/{job_name}/predictions.csv``. Predictions use AutoGluon's canonical column
             names ``item_id`` and ``timestamp``, regardless of the ``id_column`` / ``timestamp_column`` passed in.
+        backend_kwargs: Optional[dict], default = None
+            Backend-specific arguments. Same keys as ``fit()``.
 
         Returns
         -------

--- a/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
+++ b/src/autogluon/cloud/predictor/timeseries_cloud_predictor.py
@@ -58,6 +58,12 @@ class TimeSeriesCloudPredictor(CloudPredictor):
         """
         Fit the predictor with SageMaker.
 
+        Equivalent to running
+
+            TimeSeriesPredictor(**predictor_init_args).fit(train_data=train_data, **predictor_fit_args)
+
+        as a remote SageMaker training job, with the fitted predictor saved to S3.
+
         Parameters
         ----------
         train_data: Union[str, pathlib.Path, pd.DataFrame]


### PR DESCRIPTION
## Description

Cleans up user-facing docstrings on the public API classes (`TimeSeriesCloudPredictor`, `TabularCloudPredictor`, `TimeSeriesFoundationModel` and the shared `CloudPredictor` base) and demotes the Ray backend to an explicit experimental warning.
