### PR TITLE
Restrict selection of SageMaker resources

### DIFF
--- a/src/autogluon/cloud/templates/ag_cloud_sagemaker.yaml
+++ b/src/autogluon/cloud/templates/ag_cloud_sagemaker.yaml
@@ -59,8 +59,8 @@ Resources:
                   - sagemaker:ListTags
                 Resource: !Sub 'arn:aws:sagemaker:*:${AWS::AccountId}:*'
 
-              # List* APIs (except ListTags) do not support resource-level
-              # permissions and must use a wildcard resource.
+              # List* APIs (except ListTags) do not support resource-level permissions and must use a wildcard resource.
+              # See https://docs.aws.amazon.com/sagemaker/latest/dg/api-permissions-reference.html
               - Sid: SageMakerList
                 Effect: Allow
                 Action:
@@ -101,6 +101,7 @@ Resources:
                   - !Sub 'arn:aws:s3:::${AGCloudSageMakerBucket}/*'
                   - 'arn:aws:s3:::sagemaker-*/*'
 
+              # DLC images live in AWS-owned regional accounts, so ECR pulls cannot be resource-scoped.
               - Sid: ECRPull
                 Effect: Allow
                 Action:

--- a/src/autogluon/cloud/templates/ag_cloud_sagemaker.yaml
+++ b/src/autogluon/cloud/templates/ag_cloud_sagemaker.yaml
@@ -57,12 +57,18 @@ Resources:
                   - sagemaker:InvokeEndpoint
                   - sagemaker:AddTags
                   - sagemaker:ListTags
+                Resource: !Sub 'arn:aws:sagemaker:*:${AWS::AccountId}:*'
+
+              # List* APIs (except ListTags) do not support resource-level
+              # permissions and must use a wildcard resource.
+              - Sid: SageMakerList
+                Effect: Allow
+                Action:
                   - sagemaker:ListEndpoints
                   - sagemaker:ListEndpointConfigs
                   - sagemaker:ListModels
                   - sagemaker:ListTrainingJobs
                   - sagemaker:ListTransformJobs
-                  - s3:ListAllMyBuckets
                 Resource: '*'
 
               - Sid: PassExecutionRole


### PR DESCRIPTION
Issue #, if available:

Description of changes:
- Restrict SageMaker actions to the user account
- Remove unused `s3:ListAllMyBuckets`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
