### PR TITLE
Switch CI trigger from pull_request_target to pull_request

### DIFF
--- a/.github/actions/setup-env-vars/action.yml
+++ b/.github/actions/setup-env-vars/action.yml
@@ -19,7 +19,7 @@ runs:
         echo "SHORT_SHA=$short_sha" >> $GITHUB_ENV
         echo "PR_NUMBER=$pr_number" >> $GITHUB_ENV
     - name: Get Commit SHA(For pull request)
-      if: ${{ github.event_name == 'pull_request_target' }}
+      if: ${{ github.event_name == 'pull_request' }}
       shell: bash
       env:
         SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,56 +5,23 @@ on:
   schedule:
     - cron: "59 10 * * *"  # 2 hrs after the nightly image build workflow
   push:
-  pull_request_target:
-    types: [labeled, synchronize, opened]
+  pull_request:
 
 permissions:
   id-token: write
   contents: read
-  pull-requests: write  # For removing tags from the PR
+  pull-requests: write  # For commenting the docs preview link on PRs
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  permission_check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check for Actor Permission
-        id: check
-        continue-on-error: true
-        uses: prince-chrismc/check-actor-permissions-action@v3
-        with:
-          github_token: ${{ github.token }}
-          permission: write
-      - name: Debug Information
-        if: ${{ github.event_name == 'pull_request_target' }}
-        run: |
-          echo "Event Name: ${{ github.event_name }}"
-          echo "Labels: ${{ toJson(github.event.pull_request.labels) }}"
-          echo "Permitted: ${{ steps.check.outputs.permitted }}"
-          echo "Safe to Test Label Present: ${{ contains(github.event.pull_request.labels.*.name, 'safe to test') }}"
-      - name: Check PR Safe to Run
-        if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'safe to test') && steps.check.outputs.permitted == 'false' }}
-        run: exit 1
-      - name: Remove Safe to Test Label  # One commit is safe doesn't mean the next commit is safe.
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions-ecosystem/action-remove-labels@v1.3.0
-        with:
-          labels: 'safe to test'
   cloud_lint_check:
-    needs: permission_check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -78,6 +45,8 @@ jobs:
           args: "check"
           src: "src tests"
   test_general_cloud:
+    # Fork PRs cannot assume the CI role, so skip instead of failing.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       fail-fast: false
       matrix:
@@ -86,13 +55,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -110,6 +73,8 @@ jobs:
           submodule-to-test: general
           ag_version: '${{ matrix.AG_VERSION }}'
   test_tabular_cloud:
+    # Fork PRs cannot assume the CI role, so skip instead of failing.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       fail-fast: false
       matrix:
@@ -118,13 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -151,13 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -184,13 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -217,13 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -241,6 +182,8 @@ jobs:
           submodule-to-test: multimodal
           ag_version: '${{ matrix.AG_VERSION }}'
   test_timeseries_cloud:
+    # Fork PRs cannot assume the CI role, so skip instead of failing.
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     strategy:
       fail-fast: false
       matrix:
@@ -249,13 +192,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -282,13 +219,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-python@v6
         with:
           python-version: '3.11'
@@ -311,18 +242,13 @@ jobs:
           chmod +x ./.github/workflow_scripts/test_cluster.sh
           ./.github/workflow_scripts/test_cluster.sh '${{ matrix.AG_VERSION }}'
   build_doc:
-    if: ${{ github.event_name != 'schedule' }}
+    # Fork PRs cannot assume the doc role or comment on the PR, so skip instead of failing.
+    if: ${{ github.event_name != 'schedule' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     needs: [test_general_cloud, test_tabular_cloud, test_timeseries_cloud]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
         uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Setup Env Vars
         uses: ./.github/actions/setup-env-vars
       - uses: actions/setup-python@v6
@@ -341,14 +267,14 @@ jobs:
           chmod +x ./.github/workflow_scripts/build_doc.sh
           ./.github/workflow_scripts/build_doc.sh '${{ github.ref }}' '${{ github.repository }}' '${{ env.SHORT_SHA }}'
       - name: Build Doc(For pull request)
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         env:
           branch: ${{ github.event.pull_request.head.ref }}
         run: |
           chmod +x ./.github/workflow_scripts/build_doc.sh
           ./.github/workflow_scripts/build_doc.sh "$branch" '${{ github.event.pull_request.head.repo.full_name }}' '${{ env.SHORT_SHA }}' PR-'${{ github.event.number }}'
       - name: Comment on PR
-        if: ${{ github.event_name == 'pull_request_target' }}
+        if: ${{ github.event_name == 'pull_request' }}
         uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.number }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ To run a specific test:
 pytest tests/path_to_file.py::test_name
 ```
 
-Note: most tests require AWS credentials and will launch SageMaker jobs. The CI will not run automatically for external contributors — ping a maintainer to tag your PR with `safe to test`.
+Note: most tests require AWS credentials and will launch SageMaker jobs. CI cannot run them on pull requests from forks — only the lint check runs there, and the test and doc jobs are skipped. A maintainer needs to push your branch to this repository to get a full CI run against it, so ping the maintainers on your PR once it is ready for review. See [tests/README.md](tests/README.md) for details.
 
 ## Security Issue Notifications
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,4 +1,14 @@
-# Welcome to Contributing to AutoGLuon-Cloud!
-We do not run CI on your PRs directly for security reasons.
-Please @ the maintainers to add `cloud safe to test` label to the PR so that they can kick off the CI for you.
-The above statement is true for each commit you push as we cannot make assumption that your commit is always benign.
+# Welcome to Contributing to AutoGluon-Cloud!
+
+Most tests in this repo launch real SageMaker jobs and need credentials for the project's AWS
+account, so CI cannot run them on pull requests from forks. On a fork PR only the lint check runs;
+the test and doc jobs are skipped.
+
+A maintainer needs to push your branch to this repository to get a full CI run against it. Ping the
+maintainers on your PR once it is ready for review.
+
+Pure unit tests (config, serializers, IAM, etc.) do not need AWS access and can be run locally:
+
+```
+pytest tests/unittests/general/
+```


### PR DESCRIPTION
Switches CI from `pull_request_target` to `pull_request`.

`pull_request_target` required a `permission_check` job plus a `safe to test` label to decide whether a PR's code should run, and every job needed a duplicate checkout step to pick up the PR head. With `pull_request` the trigger itself scopes what runs, so all of that goes away.

Fork PRs can't obtain the CI credentials, so the AWS-touching jobs (`test_general_cloud`, `test_tabular_cloud`, `test_timeseries_cloud`) and `build_doc` are gated on `github.event.pull_request.head.repo.full_name == github.repository`. They skip cleanly on forks rather than failing, leaving lint as the only check. Maintainer branches pushed to this repo still get the full run.

Changes:
- Drop the `permission_check` job and the `safe to test` label handling
- Collapse the duplicated per-job checkout steps into one
- Add the fork guard to the four jobs needing AWS credentials or PR write access
- Update `CONTRIBUTING.md` and `tests/README.md` for the new process

Note for reviewers: if branch protection lists required status checks, it needs updating — `permission_check` no longer exists, and the guarded jobs now report as skipped on fork PRs.
