### PR TITLE
Ship ag_args as JSON instead of pickle

### DIFF
--- a/src/autogluon/cloud/backend/backend.py
+++ b/src/autogluon/cloud/backend/backend.py
@@ -1,13 +1,42 @@
 from __future__ import annotations
 
+import json
 import os
-import pickle
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 
 from ..endpoint.endpoint import Endpoint
+
+
+def dumps_ag_args(config: Dict[str, Any]) -> str:
+    """Serialize the remote-training config to JSON, raising a user-facing error on failure.
+
+    The config carries the user's predictor init/fit arguments. Some objects (search spaces,
+    custom metric objects, classes/callables in ``hyperparameters``) are not JSON-serializable;
+    when that happens we pinpoint the offending argument so the error names what the user passed.
+    """
+    try:
+        return json.dumps(config)
+    except TypeError:
+        pass
+    for group in ("predictor_init_args", "predictor_fit_args"):
+        for key, value in (config.get(group) or {}).items():
+            try:
+                json.dumps(value)
+            except TypeError as e:
+                raise TypeError(
+                    f"The value passed for `{key}` is not JSON-serializable. This can happen with "
+                    f"search spaces (Real/Categorical/Int), custom metric objects, or classes/callables "
+                    f"in `hyperparameters`. Please pass these as plain values (e.g. metric names as strings). "
+                    f"Original error: {e}"
+                ) from e
+    # Culprit is outside the known arg groups; re-raise the original error with generic guidance.
+    try:
+        return json.dumps(config)
+    except TypeError as e:
+        raise TypeError(f"The provided arguments are not JSON-serializable. Original error: {e}") from e
 
 
 class Backend(ABC):
@@ -83,18 +112,19 @@ class Backend(ABC):
     def prepare_args(self, path: str, **kwargs):
         """
         prepare parameter args required to be passed to remote AG, i.e. init args and fit args
-        The args will be saved as a pickle object
+        The args will be saved as a JSON file
 
         Parameters
         ----------
         path: str
-            Path to save the pickle file
+            Path to save the JSON file
         """
         assert self.predictor_type is not None
         config = self._construct_ag_args(**kwargs)
+        payload = dumps_ag_args(config)
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "wb") as f:
-            pickle.dump(config, f)
+        with open(path, "w") as f:
+            f.write(payload)
 
     def _construct_ag_args(**kwargs):
         raise NotImplementedError

--- a/src/autogluon/cloud/backend/ray_backend.py
+++ b/src/autogluon/cloud/backend/ray_backend.py
@@ -211,7 +211,7 @@ class RayBackend(Backend):
         image_uri = self._get_image_uri(
             framework_version=framework_version, custom_image_uri=custom_image_uri, instance_type=instance_type
         )
-        ag_args_path = os.path.join(self.local_output_path, "job", "ag_args.pkl")
+        ag_args_path = os.path.join(self.local_output_path, "job", "ag_args.json")
         self.prepare_args(
             path=ag_args_path, predictor_init_args=predictor_init_args, predictor_fit_args=predictor_fit_args
         )

--- a/src/autogluon/cloud/backend/sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/sagemaker_backend.py
@@ -2,7 +2,6 @@ import copy
 import json
 import logging
 import os
-import pickle
 import shutil
 import tarfile
 import tempfile
@@ -229,7 +228,7 @@ class SagemakerBackend(Backend):
             Any extra arguments needed to pass to fit.
             Please refer to https://sagemaker.readthedocs.io/en/stable/api/training/estimators.html#sagemaker.estimator.Framework.fit for all options
         extra_ag_args: Optional[Dict[str, Any]], default = None
-            Additional entries to merge into ``ag_args.pkl``. Use this to ship caller-specific metadata to the
+            Additional entries to merge into ``ag_args.json``. Use this to ship caller-specific metadata to the
             train script (e.g. ``predict_after_fit``, or ``id_column`` / ``timestamp_column`` for time series).
         """
         if data_channels.get("train_data") is None:
@@ -314,7 +313,7 @@ class SagemakerBackend(Backend):
                     f"`predictions_path` must be a full S3 URL ending in '.csv' or '.parquet' "
                     f"(e.g. 's3://bucket/key/predictions.parquet'), got {predictions_path!r}."
                 )
-        ag_args_path = os.path.join(self.local_output_path, "utils", "ag_args.pkl")
+        ag_args_path = os.path.join(self.local_output_path, "utils", "ag_args.json")
         self.prepare_args(path=ag_args_path, **ag_args)
         inputs = self._upload_fit_artifact(
             data_channels=data_channels,
@@ -1015,9 +1014,9 @@ class SagemakerBackend(Backend):
             return load_pd.load(local_path)
 
     def _download_ag_args_from_job(self) -> Dict[str, Any]:
-        """Fetch and unpickle the ``ag_args.pkl`` that was uploaded as the ``ag_args`` channel.
+        """Fetch and parse the ``ag_args.json`` that was uploaded as the ``ag_args`` channel.
 
-        Each training job carries the exact pickle it was launched with as an input channel,
+        Each training job carries the exact config it was launched with as an input channel,
         making this the authoritative source — independent of local-disk lifetime.
         """
         job_name = self._fit_job.job_name
@@ -1029,12 +1028,12 @@ class SagemakerBackend(Backend):
             f"Training job {job_name!r} has no `ag_args` input channel — cannot recover predictions_path."
         )
         bucket, key = s3_path_to_bucket_prefix(ag_args_uri)
-        assert key.endswith(".pkl"), f"Expected ag_args channel to point to a .pkl file, got {ag_args_uri!r}"
+        assert key.endswith(".json"), f"Expected ag_args channel to point to a .json file, got {ag_args_uri!r}"
         with tempfile.TemporaryDirectory(prefix="ag_args_") as tmpdir:
             local_path = os.path.join(tmpdir, os.path.basename(key))
             self.sagemaker_session.boto_session.client("s3").download_file(bucket, key, local_path)
-            with open(local_path, "rb") as f:
-                return pickle.load(f)
+            with open(local_path, "r") as f:
+                return json.load(f)
 
     def _construct_ag_args(self, predictor_init_args, predictor_fit_args, leaderboard, **kwargs):
         config = dict(

--- a/src/autogluon/cloud/backend/timeseries_sagemaker_backend.py
+++ b/src/autogluon/cloud/backend/timeseries_sagemaker_backend.py
@@ -38,7 +38,7 @@ class TimeSeriesSagemakerBackend(SagemakerBackend):
     ) -> None:
         """Fit a TimeSeriesPredictor in SageMaker.
 
-        ``id_column`` / ``timestamp_column`` are forwarded to the training script via ``ag_args.pkl``.
+        ``id_column`` / ``timestamp_column`` are forwarded to the training script via ``ag_args.json``.
         ``known_covariates`` (if present in ``data_channels``) is only honored when
         ``extra_ag_args["predict_after_fit"]`` is True.
         """

--- a/src/autogluon/cloud/scripts/ray_scripts/train.py
+++ b/src/autogluon/cloud/scripts/ray_scripts/train.py
@@ -1,6 +1,6 @@
 import argparse
+import json
 import os
-import pickle
 import shutil
 import time
 from datetime import datetime, timezone
@@ -91,8 +91,8 @@ if __name__ == "__main__":
         tune_data = None
         if args.tune_data is not None:
             tune_data = TabularDataset(args.tune_data)
-        with open(args.ag_args_path, "rb") as f:
-            ag_args = pickle.load(f)
+        with open(args.ag_args_path, "r") as f:
+            ag_args = json.load(f)
         predictor_init_args = ag_args["predictor_init_args"]
         predictor_fit_args = ag_args["predictor_fit_args"]
         save_path = f"ag_distributed_training_{get_utc_timestamp_now()}"

--- a/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
+++ b/src/autogluon/cloud/scripts/sagemaker_scripts/train.py
@@ -10,7 +10,6 @@ from pprint import pprint
 
 import boto3
 import pandas as pd
-import pickle
 
 from autogluon.common.loaders import load_pd
 from autogluon.common.savers import save_pd
@@ -85,8 +84,8 @@ if __name__ == "__main__":
     os.makedirs(args.output_data_dir, mode=0o777, exist_ok=True)
 
     ag_args_file = get_input_path(args.ag_args)
-    with open(ag_args_file, "rb") as f:
-        ag_args = pickle.load(f)  # AutoGluon-specific args
+    with open(ag_args_file, "r") as f:
+        ag_args = json.load(f)  # AutoGluon-specific args
 
     if args.n_gpus:
         ag_args["num_gpus"] = int(args.n_gpus)

--- a/tests/unittests/general/test_ag_args_serialization.py
+++ b/tests/unittests/general/test_ag_args_serialization.py
@@ -1,0 +1,44 @@
+"""Unit tests for the JSON serialization of remote-training args (see backend.dumps_ag_args)."""
+
+import json
+
+import pytest
+
+from autogluon.cloud.backend.backend import dumps_ag_args
+
+
+def test_when_config_is_json_native_then_roundtrips():
+    config = {
+        "predictor_type": "tabular",
+        "predictor_init_args": {"label": "y", "eval_metric": "roc_auc"},
+        "predictor_fit_args": {"presets": "best_quality", "time_limit": 60},
+        "leaderboard": True,
+    }
+    assert json.loads(dumps_ag_args(config)) == config
+
+
+def test_when_init_arg_not_serializable_then_error_names_that_arg():
+    config = {
+        "predictor_init_args": {"label": "y", "eval_metric": object()},
+        "predictor_fit_args": {},
+    }
+    with pytest.raises(TypeError) as exc:
+        dumps_ag_args(config)
+    assert "`eval_metric`" in str(exc.value)
+
+
+def test_when_fit_arg_not_serializable_then_error_names_that_arg():
+    config = {
+        "predictor_init_args": {"label": "y"},
+        "predictor_fit_args": {"presets": "best_quality", "hyperparameters": {"GBM": object}},
+    }
+    with pytest.raises(TypeError) as exc:
+        dumps_ag_args(config)
+    assert "`hyperparameters`" in str(exc.value)
+
+
+def test_error_message_does_not_leak_internal_ag_args_name():
+    config = {"predictor_init_args": {"eval_metric": object()}, "predictor_fit_args": {}}
+    with pytest.raises(TypeError) as exc:
+        dumps_ag_args(config)
+    assert "ag_args" not in str(exc.value)


### PR DESCRIPTION
## What

Ship the remote-training config (`ag_args` — predictor init/fit args + metadata) as **JSON** instead of a **pickle**.

## Why

`ag_args` was serialized with `pickle` locally and `pickle.load`-ed inside the SageMaker / Ray training container. Unpickling is arbitrary code execution, so a tampered `ag_args.pkl` (e.g. swapped in S3 before the job reads it) would run attacker-controlled code on load. JSON removes that class of risk.

## Behavior change

Objects that aren't JSON-serializable — AutoGluon search spaces (`Real`/`Categorical`/`Int`), custom metric objects, or classes/callables in `hyperparameters` — can no longer be shipped. When one is passed, `dumps_ag_args` raises an informative `TypeError` that names the offending user argument (e.g. `` `eval_metric` ``, `` `hyperparameters` ``) without leaking the internal `ag_args` name. A future opt-in `extra` cloudpickle channel can carry such objects; out of scope here.

**Backward-incompatible:** jobs launched by the old pickle code can't be read back (`get_fit_predict_results()` / attach). Acceptable during the current dev phase.

## Changes

- `backend.dumps_ag_args()` — serialize-or-raise helper; `prepare_args` writes JSON through it.
- Flip the three read sites to `json.load`: SageMaker train script, Ray train script, `_download_ag_args_from_job`.
- Rename `ag_args.pkl` → `ag_args.json`; update the channel-URI assertion and docstrings.
- Remove now-unused `import pickle`.
- Add `tests/unittests/general/test_ag_args_serialization.py` (pure unit tests, no AWS).

The Ray path gets the mechanical flip only, since that backend is slated for deprecation.

## Testing

- New unit tests pass.
- `ruff check` / `ruff format --check` clean.
