### PR TITLE
CI: run lint on pull_request in its own workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -43,46 +43,12 @@ jobs:
         uses: actions-ecosystem/action-remove-labels@v1.3.0
         with:
           labels: 'safe to test'
-  cloud_lint_check:
-    needs: permission_check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v5
-      - name: Checkout repository(Pull Request Target)
-        if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/setup-python@v6
-        with:
-          python-version: '3.11'
-      - name: Check if changes beside docs
-        uses: dorny/paths-filter@v3
-        id: changes
-        with:
-          filters: |
-            other_than_docs:
-              - '!(docs/**)**'
-      - name: Ruff Format Check
-        if: steps.changes.outputs.other_than_docs == 'true'
-        uses: astral-sh/ruff-action@v3
-        with:
-          args: "format --check"
-          src: "src tests"
-      - name: Ruff Lint Check
-        if: steps.changes.outputs.other_than_docs == 'true'
-        uses: astral-sh/ruff-action@v3
-        with:
-          args: "check"
-          src: "src tests"
   test_general_cloud:
     strategy:
       fail-fast: false
       matrix:
         AG_VERSION: ["1.5.0"]
-    needs: cloud_lint_check
+    needs: permission_check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -114,7 +80,7 @@ jobs:
       fail-fast: false
       matrix:
         AG_VERSION: ["1.5.0"]
-    needs: cloud_lint_check
+    needs: permission_check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -147,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         AG_VERSION: ["source", "1.2.0"]
-    needs: cloud_lint_check
+    needs: permission_check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -180,7 +146,7 @@ jobs:
       fail-fast: false
       matrix:
         AG_VERSION: ["source", "1.2.0"]
-    needs: cloud_lint_check
+    needs: permission_check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -213,7 +179,7 @@ jobs:
       fail-fast: false
       matrix:
         AG_VERSION: ["source", "1.2.0"]
-    needs: cloud_lint_check
+    needs: permission_check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -245,7 +211,7 @@ jobs:
       fail-fast: false
       matrix:
         AG_VERSION: ["1.5.0"]
-    needs: cloud_lint_check
+    needs: permission_check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -278,7 +244,7 @@ jobs:
       fail-fast: false
       matrix:
         AG_VERSION: ["source", "1.2.0"]
-    needs: cloud_lint_check
+    needs: permission_check
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,43 @@
+name: Lint
+
+on:
+  workflow_dispatch:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  cloud_lint_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.11'
+      - name: Check if changes beside docs
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            other_than_docs:
+              - '!(docs/**)**'
+      - name: Ruff Format Check
+        if: steps.changes.outputs.other_than_docs == 'true'
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "format --check"
+          src: "src tests"
+      - name: Ruff Lint Check
+        if: steps.changes.outputs.other_than_docs == 'true'
+        uses: astral-sh/ruff-action@v3
+        with:
+          args: "check"
+          src: "src tests"


### PR DESCRIPTION
## Problem

The lint job lived inside the `pull_request_target` CI workflow and checked out the fork's head SHA:

```yaml
uses: actions/checkout@v5
with:
  ref: ${{ github.event.pull_request.head.sha }}
```

`actions/checkout` now refuses a fork checkout in a `pull_request_target` (trusted) context — the "pwn request" guard — so **lint failed on every fork PR** before ruff even ran.

## Fix

Lint needs no secrets, so it doesn't belong in the trusted context at all.

- **New `lint.yml`** triggered on `pull_request` (+ `push`, `workflow_dispatch`). The default checkout grabs the PR code safely — no secrets, no flag, no fork-checkout risk.
- **Removed `cloud_lint_check`** from `continuous_integration.yml`.
- The AWS test jobs stay on `pull_request_target` (they need AWS secrets) and now `needs: permission_check` directly — `needs` can't span workflow files.

## Follow-up (repo settings, not code)

Since test jobs can no longer `needs:` lint across files, enforce lint via **branch protection**: mark `cloud_lint_check` as a required status check on `master`. Job ordering is replaced by merge gating.

Note: this does not touch the test jobs' own fork-checkout step — that's a separate, deliberate decision (they need `allow-unsafe-pr-checkout` + the `safe to test` label gate regardless). This PR only rescues lint.
