### PR TITLE
Migrate package metadata to [project] and enable uv project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,9 @@ celerybeat.pid
 # SageMath parsed files
 *.sage.py
 
+# uv (library, not app — devs regenerate the lockfile locally)
+uv.lock
+
 # Environments
 .env
 .venv

--- a/docs/ReleaseInstructions.md
+++ b/docs/ReleaseInstructions.md
@@ -4,7 +4,7 @@
 
 * Ensure `master` is stable: CI is green, no in-flight critical PRs.
 * Confirm `setup.py` has the intended release version (e.g. `version = "0.5.0"`).
-* Sanity-check dependency version ranges in `setup.py`:
+* Sanity-check dependency version ranges in `pyproject.toml`:
   * No major-version caps without an inline comment justifying it.
   * Every dependency has both a lower bound and an upper cap (using `<`, not `<=`).
   * Caps are at the minor level (`<x.y`), not micro (`<x.y.z`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,9 +33,37 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Topic :: Scientific/Engineering :: Image Recognition",
 ]
-# version / dependencies / optional-dependencies stay dynamic and are owned by setup.py
-# (so the RELEASE=1 -> clean version, else .dev0 logic keeps working).
-dynamic = ["version", "dependencies", "optional-dependencies"]
+# version stays dynamic and is owned by setup.py (so the RELEASE=1 -> clean
+# version, else .dev0 logic keeps working).
+dynamic = ["version"]
+dependencies = [
+    # common module provides utils with stable api across minor version
+    "autogluon.common>=0.7,<1.6",
+    # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
+    "boto3>=1.10,<2",
+    "packaging>=23.0,<27",
+    "sagemaker>=2.126.0,<3",
+    "pyarrow>=19.0.1,<25",  # lower bound to avoid https://github.com/apache/arrow/issues/45283
+    "PyYAML~=6.0",
+    "Pillow>=10.2,<13",
+    "huggingface_hub>=0.20,<2",
+    "typing_extensions>=4.0,<5",
+    # CLI dependencies (autogluon-cloud command)
+    "click>=8.0,<9",
+    "rich>=13.0,<15",
+]
+
+[project.optional-dependencies]
+ray = ["ray[default]>=2.10.0,<2.56"]
+all = [  # To allow user to pass ag objects
+    "autogluon>=0.7,<1.6",
+    "autogluon.cloud[ray]",
+]
+tests = [
+    "pytest",
+    "moto",
+    "autogluon.common>=0.7",
+]
 
 [project.urls]
 Documentation = "https://auto.gluon.ai/cloud"
@@ -45,6 +73,21 @@ Source = "https://github.com/autogluon/autogluon-cloud/"
 
 [project.scripts]
 autogluon-cloud = "autogluon.cloud.cli:main"
+
+[tool.setuptools]
+zip-safe = true
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
+namespaces = true
+
+[tool.setuptools.package-data]
+"autogluon.cloud" = [
+    "default_cluster_configs/*.yaml",
+    "utils/autogluon_dlc.json",
+    "templates/*.yaml",
+]
 
 [tool.ruff]
 line-length = 119

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,51 @@
+[build-system]
+requires = ["setuptools>=77", "wheel"]  # >=77 for PEP 639 SPDX license expression support
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "autogluon.cloud"
+description = "Train and deploy ML models in the cloud"
+readme = "README.md"
+requires-python = ">=3.10,<3.14"
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE"]
+authors = [{ name = "AutoGluon Community" }]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Education",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Intended Audience :: Customer Service",
+    "Intended Audience :: Financial and Insurance Industry",
+    "Intended Audience :: Healthcare Industry",
+    "Intended Audience :: Telecommunications Industry",
+    "Operating System :: MacOS",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: POSIX",
+    "Operating System :: Unix",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+    "Topic :: Scientific/Engineering :: Image Recognition",
+]
+# version / dependencies / optional-dependencies stay dynamic and are owned by setup.py
+# (so the RELEASE=1 -> clean version, else .dev0 logic keeps working).
+dynamic = ["version", "dependencies", "optional-dependencies"]
+
+[project.urls]
+Documentation = "https://auto.gluon.ai/cloud"
+"Bug Reports" = "https://github.com/autogluon/autogluon-cloud/issues"
+Source = "https://github.com/autogluon/autogluon-cloud/"
+"Contribute!" = "https://github.com/autogluon/autogluon-cloud/blob/master/CONTRIBUTING.md"
+
+[project.scripts]
+autogluon-cloud = "autogluon.cloud.cli:main"
+
 [tool.ruff]
 line-length = 119
 target-version = "py310"

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,6 @@ from setuptools import setup
 AUTOGLUON = "autogluon"
 CLOUD = "cloud"
 
-PYTHON_REQUIRES = ">=3.10, <3.14"
-
 
 def create_version_file(*, version):
     print("-- Building version " + version)
@@ -29,60 +27,18 @@ def update_version(version):
 def default_setup_args(*, version):
     from setuptools import find_namespace_packages
 
-    long_description = open("README.md").read()
-    name = f"{AUTOGLUON}.{CLOUD}"
     setup_args = dict(
-        name=name,
         version=version,
-        author="AutoGluon Community",
-        url="https://github.com/autogluon/autogluon-cloud",
-        description="Train and deploy AutoGluon backed models on the cloud",
-        long_description=long_description,
-        long_description_content_type="text/markdown",
-        license="Apache-2.0",
-        license_files=("LICENSE", "NOTICE"),
-        # Package info
         packages=find_namespace_packages("src"),
         package_dir={"": "src"},
         zip_safe=True,
         include_package_data=True,
-        python_requires=PYTHON_REQUIRES,
         package_data={
             "autogluon.cloud": [
                 "default_cluster_configs/*.yaml",
                 "utils/autogluon_dlc.json",
                 "templates/*.yaml",
             ],
-        },
-        classifiers=[
-            "Development Status :: 4 - Beta",
-            "Intended Audience :: Education",
-            "Intended Audience :: Developers",
-            "Intended Audience :: Science/Research",
-            "Intended Audience :: Customer Service",
-            "Intended Audience :: Financial and Insurance Industry",
-            "Intended Audience :: Healthcare Industry",
-            "Intended Audience :: Telecommunications Industry",
-            "License :: OSI Approved :: Apache Software License",
-            "Operating System :: MacOS",
-            "Operating System :: Microsoft :: Windows",
-            "Operating System :: POSIX",
-            "Operating System :: Unix",
-            "Programming Language :: Python :: 3",
-            "Programming Language :: Python :: 3.10",
-            "Programming Language :: Python :: 3.11",
-            "Programming Language :: Python :: 3.12",
-            "Programming Language :: Python :: 3.13",
-            "Topic :: Software Development",
-            "Topic :: Scientific/Engineering :: Artificial Intelligence",
-            "Topic :: Scientific/Engineering :: Information Analysis",
-            "Topic :: Scientific/Engineering :: Image Recognition",
-        ],
-        project_urls={
-            "Documentation": "https://auto.gluon.ai",
-            "Bug Reports": "https://github.com/autogluon/autogluon-cloud/issues",
-            "Source": "https://github.com/autogluon/autogluon-cloud/",
-            "Contribute!": "https://github.com/autogluon/autogluon-cloud/blob/master/CONTRIBUTING.md",
         },
     )
     return setup_args
@@ -129,10 +85,5 @@ if __name__ == "__main__":
     setup(
         install_requires=install_requires,
         extras_require=extras_require,
-        entry_points={
-            "console_scripts": [
-                "autogluon-cloud=autogluon.cloud.cli:main",
-            ],
-        },
         **setup_args,
     )

--- a/setup.py
+++ b/setup.py
@@ -24,66 +24,9 @@ def update_version(version):
     return version
 
 
-def default_setup_args(*, version):
-    from setuptools import find_namespace_packages
-
-    setup_args = dict(
-        version=version,
-        packages=find_namespace_packages("src"),
-        package_dir={"": "src"},
-        zip_safe=True,
-        include_package_data=True,
-        package_data={
-            "autogluon.cloud": [
-                "default_cluster_configs/*.yaml",
-                "utils/autogluon_dlc.json",
-                "templates/*.yaml",
-            ],
-        },
-    )
-    return setup_args
-
-
-version = "0.5.1"
-version = update_version(version)
-
-install_requires = [
-    # common module provides utils with stable api across minor version
-    "autogluon.common>=0.7,<1.6",
-    # <2 because unlikely to introduce breaking changes in minor releases. >=1.10 because 1.10 is 3 years old, no need to support older
-    "boto3>=1.10,<2",
-    "packaging>=23.0,<27",
-    "sagemaker>=2.126.0,<3",
-    "pyarrow>=19.0.1,<25",  # lower bound to avoid https://github.com/apache/arrow/issues/45283
-    "PyYAML~=6.0",
-    "Pillow>=10.2,<13",
-    "huggingface_hub>=0.20,<2",
-    "typing_extensions>=4.0,<5",
-    # CLI dependencies (autogluon-cloud command)
-    "click>=8.0,<9",
-    "rich>=13.0,<15",
-]
-
-extras_require = dict()
-
-ray_requires = ["ray[default]>=2.10.0,<2.56"]
-extras_require["ray"] = ray_requires
-
-all_requires = ["autogluon>=0.7,<1.6"] + ray_requires  # To allow user to pass ag objects
-extras_require["all"] = all_requires
-
-test_requirements = [
-    "pytest",
-    "moto",
-    "autogluon.common>=0.7",
-]
-extras_require["tests"] = test_requirements
+version = update_version("0.5.1")
 
 if __name__ == "__main__":
     create_version_file(version=version)
-    setup_args = default_setup_args(version=version)
-    setup(
-        install_requires=install_requires,
-        extras_require=extras_require,
-        **setup_args,
-    )
+    # Everything except the dynamic version lives in pyproject.toml.
+    setup(version=version)


### PR DESCRIPTION
## What

Adds a `[build-system]` + `[project]` table to `pyproject.toml` so uv recognizes this as a project — `uv sync` / `uv lock` now work (previously there was no `[project]`, so uv had nothing to resolve).

### How the split works
- **Static metadata → `[project]`**: `name`, `description`, `readme`, `license` (SPDX), `license-files`, `authors`, `classifiers`, `requires-python`, `[project.urls]`, `[project.scripts]` entry point.
- **Dynamic → still owned by `setup.py`**: `version`, `dependencies`, `optional-dependencies`. These stay in `setup.py` so the release-flow logic (`RELEASE=1` → clean `0.5.1`, else `0.5.1.dev0`) is preserved untouched. `setup.py` is trimmed to just those + version-file generation and package discovery.

Note: `[project].version` and `dynamic = ["version"]` are mutually exclusive, so hardcoding the version in pyproject would have reintroduced the manual per-release edit we removed in #264. Keeping it dynamic avoids that.

### Consistency with the main autogluon repo
- Same build backend: `setuptools.build_meta` (not hatchling).
- `setuptools>=77` — required for the PEP 639 SPDX `license = "Apache-2.0"` expression (matches autogluon's floor; `>=64` would mishandle the license field).
- `description` set to `"Train and deploy ML models in the cloud"` to match the GitHub repo tagline.

### Other
- `uv.lock` is gitignored — this is a library, not an app, so we don't pin the (huge, churny) transitive tree.
- Fixed the Documentation URL to `https://auto.gluon.ai/cloud`.
- The old `License :: OSI Approved` classifier is replaced by the PEP 639 `License-Expression` (setuptools bundles LICENSE/NOTICE).

## Verification

Built the wheel (`uvx --from build pyproject-build --wheel`) and inspected `METADATA`:
- `Name: autogluon.cloud`, `Version: 0.5.1.dev0` (dynamic version resolves)
- `Summary: Train and deploy ML models in the cloud`
- `Requires-Python: <3.14,>=3.10`, all Project-URLs present
- `License-Expression: Apache-2.0`; LICENSE + NOTICE packaged
- Entry point `autogluon-cloud = autogluon.cloud.cli:main`
- Core deps + `ray` / `all` / `tests` extras all correct
- `uv lock` resolves the full dependency tree