### PR TITLE
Add CI concurrency control and tidy version/copyright

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "Code scanning - action"
 
 on:
   push:
-    # Exclude Dependabot branches from triggering on push
-    branches-ignore:
-      - 'dependabot/**'
+    branches:
+      - master
+      - stable
   pull_request:
   schedule:
     - cron: '0 19 * * 0'

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -15,6 +15,11 @@ on:
       - 'v*'
   pull_request:
 
+concurrency:
+  # Per-ref so a tag/branch push never cancels a build for a different ref
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
 permissions:
   id-token: write
   contents: read

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -5,7 +5,7 @@ sys.path = [".", ".."] + sys.path
 
 project = "AutoGluon-Cloud"
 release = "0.5.1"
-copyright = "2023, All authors. Licensed under Apache 2.0."
+copyright = "2026, All authors. Licensed under Apache 2.0."
 author = "AutoGluon contributors"
 
 extensions = [

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ def update_version(version):
     return version
 
 
-version = update_version("0.5.1")
+version = "0.5.1"
+version = update_version(version)
 
 if __name__ == "__main__":
     create_version_file(version=version)


### PR DESCRIPTION
## Summary
- Add a per-ref `concurrency` group to the CI workflow so a superseded run gets cancelled (`cancel-in-progress`), while tag/branch pushes for different refs don't cancel each other.
- Restrict the CodeQL `push` trigger to the long-lived `master` and `stable` branches. Same-repo feature branches were firing both a `push` and a `pull_request` CodeQL run; now PRs get a single scan while merges to `master`/`stable` and the weekly scheduled scan are unaffected.
- Bump the docs copyright year to 2026.
- Split the `version` assignment in `setup.py` into two lines for readability (no behavior change).

## Test plan
- `ruff check` / `ruff format` pass (pre-commit).
- CI/CodeQL trigger behavior verified by the workflow config; no functional code changed.